### PR TITLE
Extend verify target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,49 +18,79 @@ POSTGRES_HOST ?= localhost
 POSTGRES_PORT ?= 15432
 POSTGRES_DATABASE ?= postgres
 
+.PHONY: install-tools
 install-tools: ## Install required utilities/tools
 	@command -v pdm > /dev/null || { echo >&2 "pdm is not installed. Installing..."; pip3.11 install --upgrade pip pdm; }
 
+.PHONY: pdm-lock-check
 pdm-lock-check: ## Check that the pdm.lock file is in a good shape
 	pdm lock --check --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
+.PHONY: install-glob
 install-global: install-tools pdm-lock-check ## Install ligthspeed-rag-content to global Python directories
 	pdm install --global --project . --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
+.PHONY: install-hooks
 install-hooks: install-deps-test ## Install commit hooks
 	pdm run pre-commit install
 
+.PHONY: install-deps
 install-deps: install-tools pdm-lock-check ## Install all required dependencies, according to pdm.lock
 	pdm sync --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
+.PHONY: install-deps-test
 install-deps-test: install-tools pdm-lock-check ## Install all required dev dependencies, according to pdm.lock
 	pdm sync --dev --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
+.PHONY: update-deps
 update-deps: ## Check pyproject.toml for changes, update the lock file if needed, then sync.
 	pdm install --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 	pdm install --dev --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
-check-types: ## Checks type hints in sources
+.PHONY: check-types
+check-types: ## Check types in the code.
+	@echo "Running $@ target ..."
 	pdm run mypy --namespace-packages --explicit-package-bases --strict --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs src scripts
 
+.PHONY: check-format
+check-format: ## Check that the code is properly formatted using Black and Ruff formatter.
+	@echo "Running $@ target ..."
+	pdm run black --check scripts src
+	pdm run ruff check scripts src --per-file-ignores=scripts/*:S101
+
+.PHONY: check-coverage
+check-coverage: ## Check the coverage of unit tests.
+	@echo "Running $@ target ..."
+	pdm run test
+
+.PHONY: check-code-metrics
+check-code-metrics: ## Check the code using Radon.
+	@echo "Running $@ target ..."
+	@OUTPUT=$$(pdm run radon cc -a A src/ | tee /dev/tty | tail -1) && \
+	GRADE=$$(echo $$OUTPUT | grep -oP " [A-F] " | tr -d '[:space:]') && \
+	if [ "$$GRADE" = "A" ]; then exit 0; else exit 1; fi
+
+.PHONY: format
 format: ## Format the code into unified format
 	pdm run black scripts src
 	pdm run ruff check scripts src --fix --per-file-ignores=scripts/*:S101
 	pdm run pre-commit run
 
-verify: check-types ## Verify the code using various linters
-	pdm run black --check scripts src
-	pdm run ruff check scripts src --per-file-ignores=scripts/*:S101
+.PHONY: verify
+verify: check-types check-format check-code-metrics check-coverage ## Verify the code using various linters
 
+.PHONY: build-base-image
 build-base-image: ## Build base container image
 	podman build -t $(TORCH_GROUP)-lightspeed-core-base -f Containerfile --build-arg FLAVOR=$(TORCH_GROUP)
 
+.PHONY: start-postgres
 start-postgres: ## Start postgresql from the pgvector container image
 	mkdir -pv ./postgresql/data ./output
 	podman run -d --name pgvector --rm -e POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
 	 -p $(POSTGRES_PORT):5432 \
 	 -v $(PWD)/postgresql/data:/var/lib/postgresql/data:Z pgvector/pgvector:pg16
 
+.PHONY: start-postgres-debug
 start-postgres-debug: ## Start postgresql from the pgvector container image with debugging enabled
 	mkdir -pv ./postgresql/data ./output
 	podman run --name pgvector --rm -e POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
@@ -68,6 +98,7 @@ start-postgres-debug: ## Start postgresql from the pgvector container image with
 	 -v ./postgresql/data:/var/lib/postgresql/data:Z pgvector/pgvector:pg16 \
 	 postgres -c log_statement=all -c log_destination=stderr
 
+.PHONY: help
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
 	@echo ''

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:d5c2ea1dea6f1712b0a50ec85ca008ae617576de0726cd024072836f82a9ae2f"
+content_hash = "sha256:888d5fcaf3e6ef4a485510952f6da3c1c89a5a6dd7c879d35b8c4cdd5ef50d4c"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -788,6 +788,18 @@ files = [
 ]
 
 [[package]]
+name = "mando"
+version = "0.7.1"
+summary = ""
+dependencies = [
+    "six",
+]
+files = [
+    {file = "mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a"},
+    {file = "mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 summary = ""
@@ -1343,6 +1355,19 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "radon"
+version = "6.0.1"
+summary = ""
+dependencies = [
+    "colorama",
+    "mando",
+]
+files = [
+    {file = "radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859"},
+    {file = "radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5"},
 ]
 
 [[package]]

--- a/pdm.lock.cpu
+++ b/pdm.lock.cpu
@@ -5,7 +5,7 @@
 groups = ["default", "cpu", "dev"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:d5c2ea1dea6f1712b0a50ec85ca008ae617576de0726cd024072836f82a9ae2f"
+content_hash = "sha256:888d5fcaf3e6ef4a485510952f6da3c1c89a5a6dd7c879d35b8c4cdd5ef50d4c"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -797,6 +797,18 @@ files = [
 ]
 
 [[package]]
+name = "mando"
+version = "0.7.1"
+summary = ""
+dependencies = [
+    "six",
+]
+files = [
+    {file = "mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a"},
+    {file = "mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 summary = ""
@@ -1232,6 +1244,19 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "radon"
+version = "6.0.1"
+summary = ""
+dependencies = [
+    "colorama",
+    "mando",
+]
+files = [
+    {file = "radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859"},
+    {file = "radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5"},
 ]
 
 [[package]]

--- a/pdm.lock.gpu
+++ b/pdm.lock.gpu
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "gpu"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:d5c2ea1dea6f1712b0a50ec85ca008ae617576de0726cd024072836f82a9ae2f"
+content_hash = "sha256:888d5fcaf3e6ef4a485510952f6da3c1c89a5a6dd7c879d35b8c4cdd5ef50d4c"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -797,6 +797,18 @@ files = [
 ]
 
 [[package]]
+name = "mando"
+version = "0.7.1"
+summary = ""
+dependencies = [
+    "six",
+]
+files = [
+    {file = "mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a"},
+    {file = "mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 summary = ""
@@ -1339,6 +1351,19 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "radon"
+version = "6.0.1"
+summary = ""
+dependencies = [
+    "colorama",
+    "mando",
+]
+files = [
+    {file = "radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859"},
+    {file = "radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,8 @@ ignore_missing_imports = true
 [tool.pdm]
 distribution = true
 
-[tool.pdm.dev-dependencies]
-dev = [
-    "black==24.10.0",
-    "mypy==1.12.0",
-    "ruff==0.6.9",
-    "types-requests==2.32.0.20240622",
-    "pre-commit==4.0.1",
-    "coverage>=7.6.12",
-    "huggingface-hub>=0.23.4"
-]
+[tool.pdm.scripts]
+test = {shell = "coverage run --source=src/lightspeed_rag_content -m unittest discover tests --verbose && coverage report -m --fail-under 90"}
 
 [build-system]
 requires = ["pdm-backend"]
@@ -41,9 +33,6 @@ cpu = [
 gpu = [
     "torch==2.3.1",
 ]
-
-[tool.pdm.scripts]
-test = {shell = "coverage run --source=src/lightspeed_rag_content -m unittest discover tests --verbose && coverage report -m --fail-under 90"}
 
 [project]
 name = "lightspeed-rag-content"
@@ -62,3 +51,15 @@ dependencies = [
 ]
 requires-python = "==3.11.*"
 dynamic = ["license", "readme"]
+
+[dependency-groups]
+dev = [
+    "black==24.10.0",
+    "mypy==1.12.0",
+    "ruff==0.6.9",
+    "types-requests==2.32.0.20240622",
+    "pre-commit==4.0.1",
+    "coverage>=7.6.12",
+    "huggingface-hub>=0.23.4",
+    "radon>=6.0.1",
+]


### PR DESCRIPTION
This commit:

 - Adds check-code-metrics target to Makefile to allow the users of the code to easily check the code with Radon prior to pushing to the repo. The code for the target is borrowed from [1].

 - Adds check-coverage target that runs the unittests and computes the coverage.

[1] https://github.com/davidslusser/actions_python_radon/blob/main/radon.sh