### PR TITLE
LCORE-569: Move rag-content images to quay.io

### DIFF
--- a/.github/workflows/build_and_push_dev.yaml
+++ b/.github/workflows/build_and_push_dev.yaml
@@ -1,4 +1,4 @@
-name: Build image, main branch push quay.io
+name: Build CPU image, main branch push quay.io
 
 on:
   push:
@@ -7,9 +7,10 @@ on:
     branches: ["main"]
 
 env:
+
   IMAGE_NAME: rag-content-cpu
-  IMAGE_NAMESPACE: ${{ github.repository_owner }}
-  IMAGE_REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: lightspeed-core
+  IMAGE_REGISTRY: quay.io
   LATEST_TAG: latest
   CONTAINER_FILE: Containerfile
 
@@ -68,5 +69,5 @@ jobs:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
           registry: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          username: ${{ secrets.QUAY_REGISTRY_USERNAME }}
+          password: ${{ secrets.QUAY_REGISTRY_PASSWORD }}

--- a/.github/workflows/build_and_push_dev_gpu.yaml
+++ b/.github/workflows/build_and_push_dev_gpu.yaml
@@ -1,4 +1,4 @@
-name: Build image, main branch push quay.io
+name: Build GPU image, main branch push quay.io
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
 
 env:
   IMAGE_NAME: rag-content-gpu
-  IMAGE_NAMESPACE: ${{ github.repository_owner }}
-  IMAGE_REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: lightspeed-core
+  IMAGE_REGISTRY: quay.io
   LATEST_TAG: latest
   CONTAINER_FILE: Containerfile-gpu
 
@@ -66,5 +66,5 @@ jobs:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
           registry: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          username: ${{ secrets.QUAY_REGISTRY_USERNAME }}
+          password: ${{ secrets.QUAY_REGISTRY_PASSWORD }}


### PR DESCRIPTION
## Description

LCORE-569: Move rag-content images to quay.io

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Renamed build pipelines to clearly distinguish CPU and GPU image builds.
  - Updated container publishing to Quay.io under the lightspeed-core namespace.
  - Switched authentication to dedicated Quay secrets for more secure pushes.
  - Improves reliability and clarity of development image distribution.
  - No product behavior changes; end users are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->