### PR TITLE
 LCORE-1491: doc processor: Markdown skip empty chunks

### DIFF
--- a/src/lightspeed_rag_content/document_processor.py
+++ b/src/lightspeed_rag_content/document_processor.py
@@ -95,22 +95,91 @@ class _BaseDB:
                 return True
         return False
 
-    @classmethod
-    def _filter_out_invalid_nodes(cls, nodes: list[Any]) -> list[TextNode]:
+    @staticmethod
+    def _got_content(text: str) -> bool:
+        """Check if text has content.
+
+        The following will not be considered content (returns False):
+        - Empty lines
+        - Empty code blocks
+        - Horizontal rules
+        - ATX header lines
+        - Setext header lines
+        """
+
+        def is_eq_dash(line: str) -> bool:
+            line = line.strip()
+            return bool(line) and all(char in ("=", "-") for char in line)
+
+        code_block = None
+
+        split_text = text.splitlines()
+
+        i = 0
+        while i < len(split_text):
+            raw_line = split_text[i]
+            line = raw_line.strip()
+
+            # Ignore empty lines
+            if not line:
+                i += 1
+                continue
+
+            # Code block indentation with content
+            if raw_line.startswith("    "):
+                return True
+
+            # Fenced code block start or end
+            if line.startswith("```"):
+                # Change to none in case all our content is a fenced empty code block
+                code_block = "fenced" if code_block != "fenced" else None
+                i += 1
+                continue
+
+            # Content inside a fenced code block
+            if code_block:
+                return True
+
+            # Ignore ATX header lines
+            if line.startswith("#"):
+                i += 1
+                continue
+
+            # Ignore horizontal rules
+            if is_eq_dash(line):
+                i += 1
+                continue
+
+            # Ignore if the next line declares this one as a setext header lines
+            if i + 1 < len(split_text) and is_eq_dash(split_text[i + 1]):
+                i += 2
+                continue
+
+            # Real content found
+            return True
+
+        return False
+
+    def _valid_text_node(self, text: str) -> bool:
+        """Check if text node is valid: has whitespace and has content."""
+        if self.config.doc_type in ("markdown", "html") and not self._got_content(text):
+            return False
+        return self._got_whitespace(text)
+
+    def _filter_out_invalid_nodes(self, nodes: list[Any]) -> list[TextNode]:
         """Filter out invalid nodes."""
         good_nodes = []
         for node in nodes:
-            if isinstance(node, TextNode) and cls._got_whitespace(node.text):
+            if isinstance(node, TextNode) and self._valid_text_node(node.text):
                 # Exclude given metadata during embedding
                 good_nodes.append(node)
             else:
-                LOG.debug("Skipping node without whitespace: %s", repr(node))
+                LOG.debug("Skipping invalid node: %s", repr(node))
         return good_nodes
 
-    @classmethod
-    def _split_and_filter(cls, docs: list[Document]) -> list[TextNode]:
+    def _split_and_filter(self, docs: list[Document]) -> list[TextNode]:
         nodes = Settings.text_splitter.get_nodes_from_documents(docs)
-        valid_nodes = cls._filter_out_invalid_nodes(nodes)
+        valid_nodes = self._filter_out_invalid_nodes(nodes)
         return valid_nodes
 
 

--- a/tests/test_document_processor_llama_index.py
+++ b/tests/test_document_processor_llama_index.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 import pytest
 from llama_index.core import Document
-from llama_index.core.schema import TextNode
+from llama_index.core.schema import Node, TextNode
 
 from lightspeed_rag_content import document_processor
 from tests.conftest import RagMockEmbedding
@@ -70,15 +70,108 @@ class TestDocumentProcessorLlamaIndex:
         result = doc_processor["processor"].db._got_whitespace(text)
         assert result
 
-    def test__filter_out_invalid_nodes(self, doc_processor):
-        """Test that _filter_out_invalid_nodes only returns nodes with whitespace."""
-        fake_node_0 = mock.Mock(spec=TextNode)
-        fake_node_1 = mock.Mock(spec=TextNode)
-        fake_node_0.text = "Got whitespace"
-        fake_node_1.text = "NoWhitespace"
+    def test__valid_text_node(self, doc_processor):
+        """Test that valid text node checks for got whitespace on non markdown chunker."""
+        db = doc_processor["processor"].db
+        db.config.doc_type = "plain"
 
-        result = doc_processor["processor"].db._filter_out_invalid_nodes([fake_node_0, fake_node_1])
-        assert result == [fake_node_0]
+        with (
+            mock.patch.object(db, "_got_whitespace") as mock_got_ws,
+            mock.patch.object(db, "_got_content") as mock_got_nh,
+        ):
+            text = "NoWhitespace"
+            res = db._valid_text_node(text)
+            assert res is mock_got_ws.return_value
+            mock_got_ws.assert_called_once_with(text)
+            mock_got_nh.assert_not_called()
+
+    def test__valid_text_node_markdown_non_headers_true(self, doc_processor):
+        """Test that text node is valid when markdown has non header content."""
+        db = doc_processor["processor"].db
+        db.config.doc_type = "markdown"
+
+        with (
+            mock.patch.object(db, "_got_content", return_value=True) as mock_got_nh,
+            mock.patch.object(db, "_got_whitespace") as mock_got_ws,
+        ):
+            text = "# Header\nActual content here"
+            res = db._valid_text_node(text)
+            assert res is mock_got_ws.return_value
+            mock_got_nh.assert_called_once_with(text)
+            mock_got_ws.assert_called_once_with(text)
+
+    def test__valid_text_node_markdown_non_headers_false(self, doc_processor):
+        """Test that text node is invalid when markdown only has headers."""
+        db = doc_processor["processor"].db
+        db.config.doc_type = "markdown"
+
+        with (
+            mock.patch.object(db, "_got_content", return_value=False) as mock_got_nh,
+            mock.patch.object(db, "_got_whitespace") as mock_got_ws,
+        ):
+            text = "# Header1\n# Header2\n\n"
+            res = db._valid_text_node(text)
+            assert res is False
+            mock_got_nh.assert_called_once_with(text)
+            mock_got_ws.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "# Header\nSome content",  # Header followed by content
+            "# Header1\n# Header2\nAlso here",  # Multiple headers, then content
+            "No headers, just content",  # No headers, just content
+            "# H\n# H2\n\tThis is non-header",  # Tabs and spaces before content
+            "   # H\n Header\n ======\n\tThis is non-header",  # Setext header line
+            "  ## H\nHeader\n ------\n```\n# git commit\n```",  # Fenced code block
+            " # H\n    # git commit\n",  # Indented code block
+            " Content\n\n",
+        ],
+    )
+    def test__got_content_with_content(self, doc_processor, text):
+        """Test we detect when markdown has something beside headers."""
+        db = doc_processor["processor"].db
+        assert db._got_content(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "# Only header",
+            "# Another header\n## Subheader",
+            "# Header with space \n",
+            "## \n#",
+            "#Header1\n#Header2\n#Header3",
+            "#    ",  # header with whitespace
+            "   # Header with leading space",
+            "   \n\t  \n",  # only whitespaces
+            "   \n```\n\n```\n",  # Empty fenced code block
+            "   \n      \n    \n",  # Empty indented code block
+            "  # Header\nAnother header\n====\n\n====",  # Headers and horizontal rules
+        ],
+    )
+    def test__got_content_only_headers(self, doc_processor, text):
+        """Test we detect when markdown only has headers."""
+        db = doc_processor["processor"].db
+        assert db._got_content(text) is False
+
+    def test__filter_out_invalid_nodes(self, doc_processor):
+        """Test that _filter_out_invalid_nodes checks for validity of text nodes."""
+        fake_text_node_0 = mock.Mock(spec=TextNode, text="fake_text_node_0")
+        fake_text_node_1 = mock.Mock(spec=TextNode, text="fake_text_node_1")
+        fake_node_2 = mock.Mock(spec=Node)
+
+        db = doc_processor["processor"].db
+        with mock.patch.object(db, "_valid_text_node", side_effect=(True, False)) as valid_tn_mock:
+            result = db._filter_out_invalid_nodes([fake_text_node_0, fake_text_node_1, fake_node_2])
+
+            expected_calls = [
+                mock.call(fake_text_node_0.text),
+                mock.call(fake_text_node_1.text),
+            ]
+            valid_tn_mock.assert_has_calls(expected_calls)
+            assert len(expected_calls) == valid_tn_mock.call_count
+
+        assert result == [fake_text_node_0]
 
     def test__save_index(self, mocker, doc_processor):
         """Test that _save_index sets index ID and persists the storage context."""


### PR DESCRIPTION
## Description

When processing documents using the markdown chunker (used for markdown and html files) we may end up with chunks that don't really have any useful information, as in having only headers.

For example, the following text:

    # Configuration

    ## cinder.conf

    Blah, blah

Will result in 2 chunks:

    # Configuration

and

    ## cinder.conf

    Blah, blah

With the first chunk being useless, moreover considering the second chunk has this in its metadata (that is used for the embedding):

    header_path: /Configuration

In this patch we change how we process markdown and html doc types and remove chunks that have no real content because they only have headers or only have space related characters.

The following are not considered as content on their own:
- Empty lines
- Empty code blocks
- Horizontal rules
- ATX header lines
- Setext header lines

## Type of change

- [x] New feature: LCORE-1491

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved content detection to better recognize meaningful text vs. structural/markdown-only content.

* **Refactor**
  * Validation and filtering logic moved to instance-level for clearer behavior; log message clarified when skipping invalid content.

* **Tests**
  * Expanded unit tests for plain text, markdown, header-only cases, and node-filtering behavior to ensure robust validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/rag-content/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->