### PR TITLE
Update README with official image retrieval instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ There are prebuilt two images. One with CPU support only (size cca 3.7 GB) and i
     podman pull quay.io/lightspeed-core/rag-content-gpu:latest
     ```
 
+#### Official image
+
+An official image is available on https://catalog.redhat.com/en/software/containers/explore
+It is needed search for "Lightspeed RAG Tool" in the catalog.
+
+A Red Hat official image can be retrieved using the following command:
+
+```bash
+podman pull registry.redhat.io/lightspeed-core/rag-tool-rhel9
+```
+
+NOTE: you need to register to RH registry first. Run the following command, then enter your registry token credentials when prompted by the terminal.
+
+```bash
+$ podman login registry.redhat.io
+```
+
 #### Build image locally
 
 To build the image locally, follow these steps:


### PR DESCRIPTION
Added instructions for retrieving the official Red Hat image and logging into the registry.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Prebuilt Image section with information about the official image available on the Red Hat Catalog, including instructions for pulling the image and the required authentication setup for the Red Hat container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->