### PR TITLE
LCORE-2164: AWS CUDA lab: pick a random AZ to avoid 'no capacity' errors

### DIFF
--- a/scripts/cuda/README.md
+++ b/scripts/cuda/README.md
@@ -7,7 +7,7 @@ This directory contains a small **two-node GPU lab** on EC2:
 | x86_64     | `x86_64`       | `g6.2xlarge` (NVIDIA L4 class)  | Subnet A   |
 | aarch64    | `arm64`        | `g5g.4xlarge` (NVIDIA T4G)     | Subnet B   |
 
-Both run **RHEL 9.4** (Hourly2-GP3 marketplace-style AMIs defined in `cuda_cloud_formation.yaml`). The stack creates a VPC, public subnets in **two** availability zones, security groups, and the two instances.
+Both run RHEL 9.4 (Hourly2-GP3 marketplace-style AMIs defined in `cuda_cloud_formation.yaml`). The stack creates a VPC, two public subnets (often one availability zone so both GPUs are valid and capacity is sane), security groups, and the two instances.
 
 **End-to-end automation** (stack + copy installer + unattended driver/container toolkit install + wait): `provision_cuda_lab.sh`.
 
@@ -74,13 +74,13 @@ The script creates the CloudFormation stack, waits for it, copies `install_cuda_
 
 ## CloudFormation template (`cuda_cloud_formation.yaml`)
 
-You can deploy manually; the template expects **parameters**:
+You can deploy manually; the template expects parameters:
 
 - **`username`** — name prefix.
-- **`PublicSubnetAAvailabilityZone`** / **`PublicSubnetBAvailabilityZone`** — AZs for the two public subnets (x86 and aarch64 instances). **`provision_cuda_lab.sh`** sets these from EC2 **instance-type offerings**.
-- **`AllowedIngressCidr`** — must be a valid IPv4 CIDR and **cannot** be `0.0.0.0/0`.
+- **`PublicSubnetAAvailabilityZone`** / **`PublicSubnetBAvailabilityZone`** — AZs for subnets A/B. `provision_cuda_lab.sh` sets both via `describe-instance-type-offerings`, randomly choosing among AZs where both GPU types are offered when possible (often the same AZ for both subnets).
+- **`AllowedIngressCidr`** — must be a valid IPv4 CIDR and cannot be `0.0.0.0/0`.
 
-Comments at the top of the YAML file show an example **`aws cloudformation create-stack`** invocation.
+Comments at the top of the YAML file show an example `aws cloudformation create-stack` invocation.
 
 Validate locally:
 

--- a/scripts/cuda/cuda_cloud_formation.yaml
+++ b/scripts/cuda/cuda_cloud_formation.yaml
@@ -13,10 +13,10 @@ Parameters:
     Description: "The username used to prefix AWS resource names."
   PublicSubnetAAvailabilityZone:
     Type: AWS::EC2::AvailabilityZone::Name
-    Description: "AZ for public subnet A (x86_64 g6.2xlarge). Must offer that instance type in this region."
+    Description: "AZ for public subnet A (x86_64 G6). Must offer that instance type. provision_cuda_lab.sh defaults this and subnet B from EC2 offerings (preferring same AZ when both GPUs are offered)."
   PublicSubnetBAvailabilityZone:
     Type: AWS::EC2::AvailabilityZone::Name
-    Description: "AZ for public subnet B (aarch64 g5g.4xlarge). Must offer that instance type in this region."
+    Description: "AZ for public subnet B (aarch64 G5g). Must offer that instance type. Same notes as subnet A."
   AllowedIngressCidr:
     Type: String
     Description: "IPv4 CIDR allowed for inbound SSH (22) and HTTP/S (80, 8000, 443, 8443). Use a specific range (e.g. 203.0.113.4/32); do not use 0.0.0.0/0."
@@ -65,8 +65,6 @@ Resources:
         - Key: "Name"
           Value: !Sub "${username}-vpc"
 
-  # Public subnets: AZs come from parameters (provision_cuda_lab.sh sets them from
-  # describe-instance-type-offerings for g6.2xlarge / g5g.4xlarge).
   PublicSubnetA:
     Type: "AWS::EC2::Subnet"
     Properties:

--- a/scripts/cuda/provision_cuda_lab.sh
+++ b/scripts/cuda/provision_cuda_lab.sh
@@ -111,7 +111,7 @@ cuda_lab_instance_type_aarch64() {
     | sed 's/.*InstanceType:[[:space:]]*"\([^"]*\)".*/\1/'
 }
 
-# AZs (e.g. us-east-1a) where an instance type is offered in this region.
+# AZs (e.g. us-east-1a) where EC2 lists an instance type as offered in this region (not spare capacity).
 list_azs_for_instance_type() {
   local reg="$1"
   local it="$2"
@@ -123,8 +123,19 @@ list_azs_for_instance_type() {
     --output text 2>/dev/null | tr '\t' '\n' | sort -u
 }
 
-# First AZ (alphabetically) per instance type that offers it; used as stack parameters.
-# Same ordering as sort -u on zone names from describe-instance-type-offerings.
+# Pick one pseudo-random AZ from newline-separated nonempty list $1 ($RANDOM modulo count).
+_pick_random_az() {
+  local lines=() line
+  while IFS= read -r line; do
+    lines+=("$line")
+  done < <(printf '%s\n' "$1" | sort -u)
+  ((${#lines[@]} > 0)) || return 1
+  # No trailing newline — value is reused in aws cloudformation --parameters ParameterValue=
+  printf '%s' "${lines[$((RANDOM % ${#lines[@]}))]}"
+}
+
+# Two AZ strings for subnets A/B: prefer overlap (both GPUs in one AZ avoids CFN-independent bad picks)
+# randomize overlap set to ease capacity contention vs always alphabetical us-east-1a-style pinning.
 resolve_lab_subnet_azs() {
   local reg="$1"
   local x86_type arm_type
@@ -133,35 +144,44 @@ resolve_lab_subnet_azs() {
   [[ -n "$x86_type" && -n "$arm_type" ]] \
     || die "could not parse CudaInstanceTypes from ${CFN_TEMPLATE}"
 
-  local azs_x86 azs_arm
+  local azs_x86 azs_arm common az_a az_b
   azs_x86="$(list_azs_for_instance_type "$reg" "$x86_type")"
   azs_arm="$(list_azs_for_instance_type "$reg" "$arm_type")"
   [[ -n "$azs_x86" ]] || die "no AZ offers ${x86_type} in ${reg} (required for subnet A / x86_64)."
   [[ -n "$azs_arm" ]] || die "no AZ offers ${arm_type} in ${reg} (required for subnet B / aarch64)."
 
-  local az_a az_b
-  az_a="$(echo "$azs_x86" | head -1)"
-  az_b="$(echo "$azs_arm" | head -1)"
+  common="$(comm -12 \
+    <(printf '%s\n' "$azs_x86") \
+    <(printf '%s\n' "$azs_arm"))"
+
+  if [[ -n "$(printf '%s' "$common" | tr -d '[:space:]')" ]]; then
+    az_a="$(_pick_random_az "$common")"
+    az_b="$az_a"
+  else
+    echo "note: ${x86_type} and ${arm_type} have no overlapping offered AZ in ${reg} per describe-instance-type-offerings; using separate picks per subnet (may rarely fail at launch)." >&2
+    az_a="$(_pick_random_az "$azs_x86")"
+    az_b="$(_pick_random_az "$azs_arm")"
+  fi
   printf '%s %s\n' "$az_a" "$az_b"
 }
 
-# Print offerings and the AZ pair passed into the template as PublicSubnet*AvailabilityZone.
-report_cuda_lab_instance_type_azs() {
+report_cuda_lab_subnet_az_pick() {
   local reg="$1"
   local az_a="$2"
   local az_b="$3"
-  local x86_type arm_type
+  local x86_type arm_type offered_x86 offered_arm
   x86_type="$(cuda_lab_instance_type_x86)"
   arm_type="$(cuda_lab_instance_type_aarch64)"
+  offered_x86="$(list_azs_for_instance_type "$reg" "$x86_type" | paste -sd ', ' -)"
+  offered_arm="$(list_azs_for_instance_type "$reg" "$arm_type" | paste -sd ', ' -)"
 
-  local az_x86 az_arm
-  az_x86="$(list_azs_for_instance_type "$reg" "$x86_type" | paste -sd ', ' -)"
-  az_arm="$(list_azs_for_instance_type "$reg" "$arm_type" | paste -sd ', ' -)"
-
-  echo "EC2 availability zones offering lab instance types in ${reg}:"
-  echo "  ${x86_type} (x86_64 / subnet A): ${az_x86}"
-  echo "  ${arm_type} (aarch64 / subnet B): ${az_arm}"
-  echo "Stack will use: PublicSubnetAAvailabilityZone=${az_a}, PublicSubnetBAvailabilityZone=${az_b}"
+  echo "CUDA lab instance types in ${reg}: ${x86_type} (subnet A), ${arm_type} (subnet B)."
+  echo "EC2 Offered Availability Zones (${reg}): ${x86_type}: ${offered_x86}; ${arm_type}: ${offered_arm}"
+  if [[ "$az_a" == "$az_b" ]]; then
+    echo "Stack subnets: both in ${az_a} (overlap of offered zones avoids aarch64 subnet landing in unsupported AZ)."
+  else
+    echo "Stack subnets: PublicSubnetAAvailabilityZone=${az_a}, PublicSubnetBAvailabilityZone=${az_b}"
+  fi
 }
 
 need_cmd() {
@@ -347,7 +367,7 @@ main() {
 
   local subnet_az_a subnet_az_b
   read -r subnet_az_a subnet_az_b < <(resolve_lab_subnet_azs "$region")
-  report_cuda_lab_instance_type_azs "$region" "$subnet_az_a" "$subnet_az_b"
+  report_cuda_lab_subnet_az_pick "$region" "$subnet_az_a" "$subnet_az_b"
 
   if [[ "$reuse_stack" -eq 0 ]]; then
     if aws cloudformation describe-stacks --stack-name "$stack_name" >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

Deployment of the CUDA lab on AWS sometimes fails with the following error:
```
Resource handler returned message: "We currently do not have sufficient g6.2xlarge capacity in the Availability
 Zone you requested (us-east-1a). Our system will be working on provisioning additional capacity. You can currently 
get g6.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1b, us-east-1c, 
us-east-1d, us-east-1f. (Service: Ec2, Status Code: 500, Request ID: 05caf5c9-8ae7-404e-b94b-91cdc43d0fbc) (SDK 
Attempt Count: 5)" (RequestToken: efe1e805-1541-9dc8-e8e9-03ba2782cbc7, HandlerErrorCode: 
GeneralServiceException)
```
This PR picks AZs with EC2 type availability at random, lessening the chances of the above error.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-2164

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
Tested by repeatedly deploying and tearing down the lab in the us-east-1 and us-west-2 AWS regions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified availability zone selection behavior for GPU lab CloudFormation deployments.

* **Refactor**
  * Updated subnet availability zone selection logic to randomize across available zones, preferring matching zones when both GPU types are available in the same zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->