### PR TITLE
LCORE-2091: add native PDF support to rag-content (incl. tests, LCORE-2092)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,16 +201,8 @@ directory and set the document type accordingly:
 
 HTML and PDF inputs are converted to Markdown by docling (already a dependency)
 and then chunked through the same Markdown-aware path as native Markdown — no
-manual pre-conversion step is required. You can also convert files ahead of time
-with the standalone CLIs, for example:
-
-```bash
-# Single file
-uv run python -m lightspeed_rag_content.pdf convert -i manual.pdf -o manual.md
-
-# A directory tree (structure is preserved)
-uv run python -m lightspeed_rag_content.pdf batch -i ./pdfs -o ./md
-```
+manual pre-conversion step is required. Just point `-f/--folder` at a directory
+containing them and set `--document-type` accordingly.
 
 > **Scanned / image-only PDFs are out of scope.** OCR is intentionally disabled,
 > so a PDF that contains no embedded text converts to empty or near-empty

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ different:
             embeddings_model_dir=args.model_dir,
             num_workers=args.workers,
             vector_store_type=args.vector_store_type,
+            # Pass the `-dt/--document-type` value so HTML and PDF inputs are
+            # routed through their docling readers (see "Supported Input Formats").
+            doc_type=args.doc_type,
         )
 
         # Load and embed the documents, this method can be called multiple times
@@ -182,6 +185,40 @@ different:
         # Save the new vector database to the output directory
         document_processor.save(args.index, args.output)
     ```
+
+### Supported Input Formats
+
+`rag-content` selects how to read each input file from the `-dt/--document-type`
+value (`text` by default). Drop the matching files into the `-f/--folder`
+directory and set the document type accordingly:
+
+| `--document-type` | Input files            | How it is read                                   |
+| ----------------- | ---------------------- | ------------------------------------------------ |
+| `text`            | `.txt`                 | Read as plain text.                              |
+| `markdown`        | `.md`                  | Read as Markdown and chunked on headings.        |
+| `html`            | `.html`, `.htm`        | Converted to Markdown with [docling].            |
+| `pdf`             | `.pdf`                 | Converted to Markdown with [docling].            |
+
+HTML and PDF inputs are converted to Markdown by docling (already a dependency)
+and then chunked through the same Markdown-aware path as native Markdown — no
+manual pre-conversion step is required. You can also convert files ahead of time
+with the standalone CLIs, for example:
+
+```bash
+# Single file
+uv run python -m lightspeed_rag_content.pdf convert -i manual.pdf -o manual.md
+
+# A directory tree (structure is preserved)
+uv run python -m lightspeed_rag_content.pdf batch -i ./pdfs -o ./md
+```
+
+> **Scanned / image-only PDFs are out of scope.** OCR is intentionally disabled,
+> so a PDF that contains no embedded text converts to empty or near-empty
+> Markdown. The reader does not error in this case; it logs a warning naming the
+> file so the condition is visible in your processing logs. Run such PDFs through
+> a separate OCR step before ingestion.
+
+[docling]: https://github.com/docling-project/docling
 
 ### YAML Frontmatter Support
 

--- a/src/lightspeed_rag_content/document_processor.py
+++ b/src/lightspeed_rag_content/document_processor.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Optional, Union, cast
 
 import faiss
 from llama_index.core import Settings, SimpleDirectoryReader, VectorStoreIndex
@@ -42,6 +42,45 @@ if TYPE_CHECKING:
     from llama_index.core.vector_stores.types import BasePydanticVectorStore
 
 LOG = logging.getLogger(__name__)
+
+# Doc types whose readers emit Markdown (HTML and PDF go through docling, which
+# exports Markdown) and therefore share the MarkdownNodeParser chunking path and
+# the Markdown-aware content-validity filter. Defined once so the predicate
+# cannot drift between its call sites.
+MARKDOWN_COMPATIBLE_DOC_TYPES: Final[tuple[str, ...]] = ("markdown", "html", "pdf")
+
+
+def _default_file_extractor(doc_type: str) -> Optional[dict[str, BaseReader]]:
+    """Build the default docling-backed file_extractor for a document type.
+
+    HTML and PDF inputs must be routed through their docling readers; otherwise
+    SimpleDirectoryReader falls back to llama-index's generic readers, which
+    bypass docling's layout/table parsing and produce poor (or no) text. Markdown
+    and plain text use the default readers and need no extractor.
+
+    Args:
+        doc_type: The configured document type.
+
+    Returns:
+        A mapping of file extension to reader, or None when the default readers
+        are appropriate.
+    """
+    if doc_type == "pdf":
+        # Imported lazily so that importing this module (e.g. for the markdown or
+        # postgres flow) does not pull in docling and its heavy dependencies.
+        from lightspeed_rag_content.pdf import (  # pylint: disable=import-outside-toplevel
+            PDFReader,
+        )
+
+        return {".pdf": PDFReader()}
+    if doc_type == "html":
+        from lightspeed_rag_content.html import (  # pylint: disable=import-outside-toplevel
+            HTMLReader,
+        )
+
+        reader = HTMLReader()
+        return {".html": reader, ".htm": reader}
+    return None
 
 
 class _Config:
@@ -72,7 +111,7 @@ class _BaseDB:
             if config.manual_chunking:
                 Settings.chunk_size = self.config.chunk_size
                 Settings.chunk_overlap = self.config.chunk_overlap
-            if config.doc_type in ("markdown", "html"):
+            if config.doc_type in MARKDOWN_COMPATIBLE_DOC_TYPES:
                 Settings.node_parser = MarkdownNodeParser()
             return
 
@@ -83,8 +122,9 @@ class _BaseDB:
                 model_name=str(self.config.embeddings_model_dir)
             )
             Settings.llm = resolve_llm(None)
-        # HTML uses MarkdownNodeParser since HTMLReader converts to Markdown
-        if config.doc_type in ("markdown", "html"):
+        # HTML and PDF use MarkdownNodeParser since their docling readers convert
+        # to Markdown.
+        if config.doc_type in MARKDOWN_COMPATIBLE_DOC_TYPES:
             Settings.node_parser = MarkdownNodeParser()
 
     @staticmethod
@@ -162,7 +202,7 @@ class _BaseDB:
 
     def _valid_text_node(self, text: str) -> bool:
         """Check if text node is valid: has whitespace and has content."""
-        if self.config.doc_type in ("markdown", "html") and not self._got_content(text):
+        if self.config.doc_type in MARKDOWN_COMPATIBLE_DOC_TYPES and not self._got_content(text):
             return False
         return self._got_whitespace(text)
 
@@ -865,6 +905,13 @@ class DocumentProcessor:
         Documents with titles in this list will be included in the vector database
         regardless of their url_reachable status.
         """
+        # When the caller does not supply an extractor, route HTML/PDF inputs
+        # through their docling readers based on the configured doc_type so the
+        # shipped CLIs (generate_embeddings.py, custom processors) parse them
+        # with docling instead of llama-index's generic fallback readers.
+        if file_extractor is None:
+            file_extractor = _default_file_extractor(self.config.doc_type)
+
         reader = SimpleDirectoryReader(
             str(docs_dir),
             recursive=True,

--- a/src/lightspeed_rag_content/pdf/__init__.py
+++ b/src/lightspeed_rag_content/pdf/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""A package for processing PDF files using docling for conversion to Markdown."""
+
+from lightspeed_rag_content.pdf.pdf_reader import PDFReader, convert_pdf_file_to_markdown
+
+__all__ = ["PDFReader", "convert_pdf_file_to_markdown"]

--- a/src/lightspeed_rag_content/pdf/__main__.py
+++ b/src/lightspeed_rag_content/pdf/__main__.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""CLI for converting PDF files to Markdown using docling.
+
+This module provides a command-line interface for converting PDF files
+to Markdown format. It can convert single files or batch convert entire
+directories.
+
+Usage:
+    python -m lightspeed_rag_content.pdf convert -i input.pdf -o output.md
+    python -m lightspeed_rag_content.pdf batch -i ./pdf_dir -o ./md_dir
+"""
+
+# The PDF CLI deliberately mirrors the HTML CLI's structure (see the BYOK PDF
+# spec); a shared base is an explicit, deferred follow-up. Until then, suppress
+# duplicate-code reports against html/__main__.py.
+# pylint: disable=duplicate-code
+
+import argparse
+import sys
+from pathlib import Path
+
+from lightspeed_rag_content.pdf.pdf_reader import PDFReader
+from lightspeed_rag_content.utils import (
+    add_input_file_argument,
+    run_cli_command,
+    setup_cli_logging,
+)
+
+LOG = setup_cli_logging(__package__)
+
+
+def main_convert(args: argparse.Namespace) -> None:
+    """Convert a single PDF file to Markdown."""
+    try:
+        reader = PDFReader()
+        documents = reader.load_data(args.input_file)
+
+        output_path = args.output_file
+        if output_path is None:
+            output_path = args.input_file.with_suffix(".md")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(documents[0].text, encoding="utf-8")
+
+        LOG.info("Converted %s -> %s", args.input_file, output_path)
+    except (FileNotFoundError, RuntimeError) as e:
+        LOG.error(str(e))
+        sys.exit(1)
+
+
+def main_batch(args: argparse.Namespace) -> None:
+    """Batch convert PDF files in a directory to Markdown."""
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir) if args.output_dir else input_dir
+
+    if not input_dir.is_dir():
+        LOG.error("Input directory does not exist: %s", input_dir)
+        sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    reader = PDFReader()
+    pdf_files = list(input_dir.glob("**/*.pdf"))
+
+    if not pdf_files:
+        LOG.warning("No PDF files found in %s", input_dir)
+        return
+
+    success_count = 0
+    error_count = 0
+
+    for pdf_file in pdf_files:
+        try:
+            # Preserve directory structure
+            relative_path = pdf_file.relative_to(input_dir)
+            output_file = output_dir / relative_path.with_suffix(".md")
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+
+            documents = reader.load_data(pdf_file)
+            output_file.write_text(documents[0].text, encoding="utf-8")
+
+            LOG.info("Converted: %s -> %s", pdf_file.name, output_file.name)
+            success_count += 1
+        except (FileNotFoundError, RuntimeError) as e:
+            LOG.error("Failed to convert %s: %s", pdf_file, e)
+            error_count += 1
+
+    LOG.info("Batch conversion complete: %d succeeded, %d failed", success_count, error_count)
+
+    if error_count > 0:
+        sys.exit(1)
+
+
+def get_argument_parser() -> argparse.ArgumentParser:
+    """Get ArgumentParser for lightspeed_rag_content.pdf module."""
+    parser = argparse.ArgumentParser(
+        description="Convert PDF files to Markdown format using docling.",
+        prog=__package__,
+    )
+    subparser = parser.add_subparsers(dest="command", required=True)
+
+    # Single file conversion
+    convert_parser = subparser.add_parser(
+        "convert",
+        help="Convert a single PDF file to Markdown.",
+    )
+    add_input_file_argument(convert_parser, "PDF file to convert.")
+    convert_parser.add_argument(
+        "-o",
+        "--output-file",
+        required=False,
+        type=Path,
+        help="Output Markdown file path. Defaults to input file with .md extension.",
+    )
+
+    # Batch conversion
+    batch_parser = subparser.add_parser(
+        "batch",
+        help="Batch convert PDF files in a directory.",
+    )
+    batch_parser.add_argument(
+        "-i",
+        "--input-dir",
+        required=True,
+        type=Path,
+        help="Directory containing PDF files to convert.",
+    )
+    batch_parser.add_argument(
+        "-o",
+        "--output-dir",
+        required=False,
+        type=Path,
+        help="Output directory for Markdown files. Defaults to input directory.",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    run_cli_command(
+        get_argument_parser(),
+        {"convert": main_convert, "batch": main_batch},
+    )

--- a/src/lightspeed_rag_content/pdf/pdf_reader.py
+++ b/src/lightspeed_rag_content/pdf/pdf_reader.py
@@ -19,10 +19,10 @@ interface, allowing PDF files to be read and converted to Markdown format using
 the docling library. PDF parsing is docling's primary capability: it performs
 layout analysis, reading-order detection, and table-structure recognition.
 
-OCR is intentionally disabled (see the BYOK PDF spec, requirement R5): scanned or
-image-only PDFs are out of scope and convert to empty or near-empty Markdown
-without erroring. Per R7, load_data emits a warning when that happens so the
-condition is visible in the caller's logs rather than degrading silently.
+OCR is intentionally disabled: scanned or image-only PDFs are out of scope and
+convert to empty or near-empty Markdown without erroring. When that happens,
+load_data emits a warning so the condition is visible in the caller's logs rather
+than degrading silently.
 
 Typical usage example:
 
@@ -61,9 +61,9 @@ from llama_index.core.schema import Document
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
-# Markdown shorter than this (after stripping) is treated as "empty output",
-# the likely signature of a scanned/image-only PDF given OCR is disabled (R5).
-# Kept small and module-level so it is easy to find and tune (R7).
+# Markdown shorter than this (after stripping) is treated as "empty output", the
+# likely signature of a scanned/image-only PDF: OCR is disabled, so a PDF with no
+# text layer extracts nothing. Module-level so it is easy to find and tune.
 EMPTY_OUTPUT_THRESHOLD: Final[int] = 50
 
 
@@ -131,8 +131,8 @@ class PDFReader(BaseReader):
             raise RuntimeError(f"Failed to convert PDF file '{file_path}': {exc}") from exc
 
         if len(markdown_content.strip()) < EMPTY_OUTPUT_THRESHOLD:
-            # R5/R7: most likely a scanned/image-only PDF. Surface it loudly
-            # instead of producing a silently near-empty vector store entry.
+            # Most likely a scanned/image-only PDF (no extractable text, OCR
+            # off). Surface it loudly instead of silently indexing an empty chunk.
             LOG.warning(
                 "PDF produced little or no text (%d chars): %s. It may be scanned or "
                 "image-only; OCR is disabled, so no text was extracted.",

--- a/src/lightspeed_rag_content/pdf/pdf_reader.py
+++ b/src/lightspeed_rag_content/pdf/pdf_reader.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""PDF Reader using docling for conversion to Markdown.
+
+This module provides a PDFReader class that implements llama-index's BaseReader
+interface, allowing PDF files to be read and converted to Markdown format using
+the docling library. PDF parsing is docling's primary capability: it performs
+layout analysis, reading-order detection, and table-structure recognition.
+
+OCR is intentionally disabled (see the BYOK PDF spec, requirement R5): scanned or
+image-only PDFs are out of scope and convert to empty or near-empty Markdown
+without erroring. Per R7, load_data emits a warning when that happens so the
+condition is visible in the caller's logs rather than degrading silently.
+
+Typical usage example:
+
+    >>> from lightspeed_rag_content.pdf import PDFReader
+    >>> reader = PDFReader()
+    >>> documents = reader.load_data(Path("document.pdf"))
+
+The reader can be used with llama-index's SimpleDirectoryReader via file_extractor:
+
+    >>> from llama_index.core import SimpleDirectoryReader
+    >>> reader = SimpleDirectoryReader(
+    ...     "docs/",
+    ...     file_extractor={".pdf": PDFReader()}
+    ... )
+    >>> docs = reader.load_data()
+"""
+
+# The PDF reader deliberately mirrors the HTML reader's structure (see the BYOK
+# PDF spec); a shared DoclingReader base is an explicit, deferred follow-up. Until
+# then, suppress duplicate-code reports against html_reader.py.
+# pylint: disable=duplicate-code
+
+import logging
+from pathlib import Path
+from typing import Any, Final, Optional
+
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    TableFormerMode,
+    TableStructureOptions,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+LOG: logging.Logger = logging.getLogger(__name__)
+
+# Markdown shorter than this (after stripping) is treated as "empty output",
+# the likely signature of a scanned/image-only PDF given OCR is disabled (R5).
+# Kept small and module-level so it is easy to find and tune (R7).
+EMPTY_OUTPUT_THRESHOLD: Final[int] = 50
+
+
+class PDFReader(BaseReader):
+    """Read PDF files and convert them to Markdown using docling.
+
+    This reader implements the llama-index BaseReader interface, making it
+    compatible with SimpleDirectoryReader's file_extractor parameter.
+
+    The reader uses docling's DocumentConverter with a PDF pipeline tuned for
+    offline indexing: OCR off, table-structure recognition on in ACCURATE mode.
+
+    Attributes:
+        converter: The docling DocumentConverter instance used for conversion.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the PDFReader with a PDF-tuned docling DocumentConverter."""
+        pipeline_options = PdfPipelineOptions()
+        pipeline_options.do_ocr = False
+        pipeline_options.do_table_structure = True
+        pipeline_options.table_structure_options = TableStructureOptions(
+            mode=TableFormerMode.ACCURATE
+        )
+        self.converter = DocumentConverter(
+            allowed_formats=[InputFormat.PDF],
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+            },
+        )
+
+    def load_data(  # pylint: disable=arguments-differ
+        self,
+        file: Path,
+        extra_info: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        """Load and convert a PDF file to a Document.
+
+        Args:
+            file: Path to the PDF file to read.
+            extra_info: Optional metadata to include in the Document.
+            **kwargs: Additional keyword arguments (unused, for BaseReader compatibility).
+
+        Returns:
+            A list containing a single Document with the converted Markdown content.
+
+        Raises:
+            FileNotFoundError: If the specified file does not exist.
+            RuntimeError: If conversion fails.
+        """
+        del kwargs
+        file_path = Path(file)
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"PDF file not found: {file_path}")
+
+        LOG.info("Converting PDF file to Markdown: %s", file_path)
+
+        try:
+            result = self.converter.convert(str(file_path))
+            markdown_content = result.document.export_to_markdown()
+        except Exception as exc:
+            LOG.error("Failed to convert PDF file %s: %s", file_path, exc)
+            raise RuntimeError(f"Failed to convert PDF file '{file_path}': {exc}") from exc
+
+        if len(markdown_content.strip()) < EMPTY_OUTPUT_THRESHOLD:
+            # R5/R7: most likely a scanned/image-only PDF. Surface it loudly
+            # instead of producing a silently near-empty vector store entry.
+            LOG.warning(
+                "PDF produced little or no text (%d chars): %s. It may be scanned or "
+                "image-only; OCR is disabled, so no text was extracted.",
+                len(markdown_content.strip()),
+                file_path,
+            )
+        else:
+            LOG.debug("Successfully converted %s to Markdown", file_path)
+
+        metadata = dict(extra_info) if extra_info else {}
+        metadata["file_path"] = str(file_path)
+        metadata["file_name"] = file_path.name
+
+        return [Document(text=markdown_content, metadata=metadata)]
+
+
+def convert_pdf_file_to_markdown(file_path: str | Path) -> str:
+    """Convert a PDF file to Markdown format.
+
+    This is a convenience function for standalone PDF to Markdown conversion.
+
+    Args:
+        file_path: Path to the PDF file to convert.
+
+    Returns:
+        The converted Markdown content as a string.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        RuntimeError: If conversion fails.
+    """
+    reader = PDFReader()
+    documents = reader.load_data(Path(file_path))
+    return documents[0].text

--- a/src/lightspeed_rag_content/utils.py
+++ b/src/lightspeed_rag_content/utils.py
@@ -136,7 +136,7 @@ def get_common_arg_parser() -> argparse.ArgumentParser:
         "--document-type",
         dest="doc_type",
         default="text",
-        choices=["text", "markdown", "html"],
+        choices=["text", "markdown", "html", "pdf"],
         help="The type of the document which is to be added to the RAG.",
     )
     return parser

--- a/tests/pdf/__init__.py
+++ b/tests/pdf/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Tests for the PDF reader and CLI package."""

--- a/tests/pdf/conftest.py
+++ b/tests/pdf/conftest.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Shared fixtures and helpers for PDF tests."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+# Marker strings baked into fixture.pdf (see generate_fixture.py).
+FIXTURE_HEADING = "Red Hat OpenShift Lightspeed"
+FIXTURE_MARKERS = ("Raleigh", "BYOK")
+
+
+def _docling_models_available() -> bool:
+    """Return True if docling's HF-cached models are present locally.
+
+    Real PDF conversion downloads layout/table models from the Hugging Face hub
+    on first use. CI images are expected to pre-cache them. When they are absent
+    (and especially when offline), the real-conversion tests are skipped rather
+    than failing, so the suite stays green without the multi-gigabyte download.
+    """
+    hf_home = os.environ.get("HF_HOME") or os.path.expanduser("~/.cache/huggingface")
+    hub = Path(hf_home) / "hub"
+    return hub.exists() and any(hub.glob("models--docling-project--*"))
+
+
+requires_docling_models = pytest.mark.skipif(
+    not _docling_models_available(),
+    reason="docling models are not cached locally; pre-cache them to run real PDF conversion",
+)
+
+
+@pytest.fixture(name="fixture_pdf")
+def fixture_pdf_fixture() -> Path:
+    """Path to the committed tiny text-extractable PDF fixture."""
+    return Path(__file__).with_name("fixture.pdf")
+
+
+@pytest.fixture(name="restore_llama_index_settings")
+def restore_llama_index_settings_fixture():
+    """Restore llama_index's global Settings.node_parser after the test.
+
+    DocumentProcessor mutates the process-wide llama_index ``Settings`` singleton
+    (it sets ``node_parser`` to a MarkdownNodeParser for markdown/html/pdf). A
+    MarkdownNodeParser has no ``chunk_size``, so if it leaks into a later test the
+    ``Settings.chunk_size`` setter raises. Each rag-content run is its own process
+    in production, so this only matters for in-process test isolation. Reset to the
+    default splitter on teardown so other test modules are unaffected.
+    """
+    from llama_index.core import Settings
+    from llama_index.core.node_parser import SentenceSplitter
+
+    try:
+        yield
+    finally:
+        Settings.node_parser = SentenceSplitter()

--- a/tests/pdf/fixture.pdf
+++ b/tests/pdf/fixture.pdf
@@ -1,0 +1,42 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 225 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 720 Tm
+(Red Hat OpenShift Lightspeed) Tj
+/F1 12 Tf
+1 0 0 1 72 690 Tm
+(The capital of OpenShift is Raleigh.) Tj
+/F1 12 Tf
+1 0 0 1 72 660 Tm
+(BYOK ingestion proves this sentence came from the PDF.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000517 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+587
+%%EOF

--- a/tests/pdf/generate_fixture.py
+++ b/tests/pdf/generate_fixture.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Zero-dependency generator for the tiny text-extractable PDF test fixture.
+
+Run this to (re)generate ``fixture.pdf`` next to this file::
+
+    python tests/pdf/generate_fixture.py
+
+It writes a minimal, valid single-page PDF (correct xref offsets, no third-party
+libraries) whose extracted text contains known marker strings the tests assert
+on. The first line uses a larger font so docling infers it as a Markdown heading.
+"""
+
+import sys
+from pathlib import Path
+
+# Lines of (text, x, y, font_size) placed in absolute PDF user space (origin at
+# the bottom-left of a 612x792 "letter" page).
+FIXTURE_LINES: list[tuple[str, int, int, int]] = [
+    ("Red Hat OpenShift Lightspeed", 72, 720, 18),
+    ("The capital of OpenShift is Raleigh.", 72, 690, 12),
+    ("BYOK ingestion proves this sentence came from the PDF.", 72, 660, 12),
+]
+
+
+def build_pdf(lines: list[tuple[str, int, int, int]]) -> bytes:
+    """Build a minimal one-page PDF from absolutely-positioned text lines.
+
+    Each tuple in ``lines`` is ``(text, x, y, font_size)`` placed in PDF user
+    space. Returns the PDF file content as bytes.
+    """
+    parts = [b"BT"]
+    for text, x, y, size in lines:
+        escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        parts.append(b"/F1 %d Tf" % size)
+        parts.append(b"1 0 0 1 %d %d Tm" % (x, y))
+        parts.append(b"(%s) Tj" % escaped.encode("latin-1"))
+    parts.append(b"ET")
+    content = b"\n".join(parts)
+
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length %d >>\nstream\n%s\nendstream" % (len(content), content),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (index, obj)
+
+    xref_pos = len(out)
+    size = len(objects) + 1
+    out += b"xref\n0 %d\n" % size
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        size,
+        xref_pos,
+    )
+    return bytes(out)
+
+
+def main() -> None:
+    """Write the fixture PDF next to this script (or to argv[1])."""
+    default = Path(__file__).with_name("fixture.pdf")
+    out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else default
+    out_path.write_bytes(build_pdf(FIXTURE_LINES))
+    print(f"wrote {out_path} ({out_path.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pdf/test__main__.py
+++ b/tests/pdf/test__main__.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Tests for the PDF CLI module (docling mocked via PDFReader)."""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from lightspeed_rag_content.pdf.__main__ import (
+    get_argument_parser,
+    main_batch,
+    main_convert,
+)
+
+CONVERTED_MARKDOWN = "# Converted Markdown\n\nContent here."
+
+
+@pytest.fixture(name="mock_pdf_reader")
+def mock_pdf_reader_fixture(mocker):
+    """Mock PDFReader for CLI tests."""
+    mock_document = mocker.MagicMock()
+    mock_document.text = CONVERTED_MARKDOWN
+
+    mock_reader_instance = mocker.MagicMock()
+    mock_reader_instance.load_data.return_value = [mock_document]
+
+    mock_reader_class = mocker.patch(
+        "lightspeed_rag_content.pdf.__main__.PDFReader",
+        return_value=mock_reader_instance,
+    )
+    return {
+        "reader_class": mock_reader_class,
+        "reader": mock_reader_instance,
+        "document": mock_document,
+    }
+
+
+@pytest.fixture(name="pdf_file")
+def pdf_file_fixture(tmp_path):
+    """Create a placeholder PDF file (docling is mocked)."""
+    file_path = tmp_path / "test.pdf"
+    file_path.write_bytes(b"%PDF-1.4 placeholder")
+    return file_path
+
+
+class TestPdfMainConvert:
+    """Tests for main_convert."""
+
+    def test_main_convert_success(self, mock_pdf_reader, pdf_file, tmp_path):
+        """A single file is converted and written to the requested output path."""
+        output_file = tmp_path / "output.md"
+        args = argparse.Namespace(input_file=pdf_file, output_file=output_file)
+
+        main_convert(args)
+
+        assert output_file.read_text() == CONVERTED_MARKDOWN
+        mock_pdf_reader["reader"].load_data.assert_called_once_with(pdf_file)
+
+    def test_main_convert_default_output(self, mock_pdf_reader, pdf_file):
+        """Without -o the output path defaults to the input with a .md suffix."""
+        args = argparse.Namespace(input_file=pdf_file, output_file=None)
+
+        main_convert(args)
+
+        expected_output = pdf_file.with_suffix(".md")
+        assert expected_output.read_text() == CONVERTED_MARKDOWN
+
+    def test_main_convert_file_not_found(self, mock_pdf_reader, tmp_path):
+        """A FileNotFoundError from the reader exits non-zero."""
+        mock_pdf_reader["reader"].load_data.side_effect = FileNotFoundError("File not found")
+        args = argparse.Namespace(input_file=tmp_path / "nonexistent.pdf", output_file=None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main_convert(args)
+
+        assert exc_info.value.code == 1
+
+    def test_main_convert_runtime_error(self, mock_pdf_reader, pdf_file, tmp_path):
+        """A RuntimeError from the reader exits non-zero."""
+        mock_pdf_reader["reader"].load_data.side_effect = RuntimeError("Conversion failed")
+        args = argparse.Namespace(input_file=pdf_file, output_file=tmp_path / "output.md")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main_convert(args)
+
+        assert exc_info.value.code == 1
+
+
+class TestPdfMainBatch:
+    """Tests for main_batch."""
+
+    def test_main_batch_success(self, mock_pdf_reader, tmp_path):
+        """All PDFs in a directory are converted."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "file1.pdf").write_bytes(b"%PDF-1.4 a")
+        (input_dir / "file2.pdf").write_bytes(b"%PDF-1.4 b")
+
+        output_dir = tmp_path / "output"
+        main_batch(argparse.Namespace(input_dir=input_dir, output_dir=output_dir))
+
+        assert (output_dir / "file1.md").exists()
+        assert (output_dir / "file2.md").exists()
+
+    def test_main_batch_default_output_dir(self, mock_pdf_reader, tmp_path):
+        """Without -o the output lands next to the input files."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "test.pdf").write_bytes(b"%PDF-1.4 a")
+
+        main_batch(argparse.Namespace(input_dir=input_dir, output_dir=None))
+
+        assert (input_dir / "test.md").exists()
+
+    def test_main_batch_nonexistent_directory(self, mock_pdf_reader, tmp_path):
+        """A missing input directory exits non-zero."""
+        args = argparse.Namespace(input_dir=tmp_path / "nonexistent", output_dir=tmp_path / "out")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main_batch(args)
+
+        assert exc_info.value.code == 1
+
+    def test_main_batch_no_pdf_files(self, mock_pdf_reader, tmp_path, caplog):
+        """An empty directory logs a warning and does not raise."""
+        input_dir = tmp_path / "empty"
+        input_dir.mkdir()
+
+        main_batch(argparse.Namespace(input_dir=input_dir, output_dir=None))
+
+        assert "No PDF files found" in caplog.text
+
+    def test_main_batch_with_errors(self, mock_pdf_reader, tmp_path):
+        """A failing file makes the batch exit non-zero."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "good.pdf").write_bytes(b"%PDF-1.4 a")
+        (input_dir / "bad.pdf").write_bytes(b"%PDF-1.4 b")
+
+        mock_pdf_reader["reader"].load_data.side_effect = [
+            [mock_pdf_reader["document"]],
+            RuntimeError("Conversion failed"),
+        ]
+
+        args = argparse.Namespace(input_dir=input_dir, output_dir=tmp_path / "output")
+        with pytest.raises(SystemExit) as exc_info:
+            main_batch(args)
+
+        assert exc_info.value.code == 1
+
+    def test_main_batch_preserves_directory_structure(self, mock_pdf_reader, tmp_path):
+        """Subdirectory structure is preserved in the output."""
+        input_dir = tmp_path / "input"
+        sub_dir = input_dir / "subdir"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "nested.pdf").write_bytes(b"%PDF-1.4 a")
+
+        output_dir = tmp_path / "output"
+        main_batch(argparse.Namespace(input_dir=input_dir, output_dir=output_dir))
+
+        assert (output_dir / "subdir" / "nested.md").exists()
+
+
+class TestGetArgumentParser:
+    """Tests for get_argument_parser."""
+
+    def test_returns_argument_parser(self):
+        """The factory returns an ArgumentParser."""
+        assert isinstance(get_argument_parser(), argparse.ArgumentParser)
+
+    def test_convert_command(self):
+        """The convert subcommand parses input and output paths."""
+        args = get_argument_parser().parse_args(["convert", "-i", "in.pdf", "-o", "out.md"])
+        assert args.command == "convert"
+        assert args.input_file == Path("in.pdf")
+        assert args.output_file == Path("out.md")
+
+    def test_convert_command_default_output(self):
+        """The convert subcommand allows omitting the output path."""
+        args = get_argument_parser().parse_args(["convert", "-i", "in.pdf"])
+        assert args.command == "convert"
+        assert args.input_file == Path("in.pdf")
+        assert args.output_file is None
+
+    def test_batch_command(self):
+        """The batch subcommand parses input and output directories."""
+        args = get_argument_parser().parse_args(["batch", "-i", "./pdfs", "-o", "./md"])
+        assert args.command == "batch"
+        assert args.input_dir == Path("./pdfs")
+        assert args.output_dir == Path("./md")
+
+    def test_batch_command_default_output(self):
+        """The batch subcommand allows omitting the output directory."""
+        args = get_argument_parser().parse_args(["batch", "-i", "./pdfs"])
+        assert args.command == "batch"
+        assert args.input_dir == Path("./pdfs")
+        assert args.output_dir is None
+
+    def test_missing_command_raises_error(self):
+        """No subcommand exits non-zero."""
+        with pytest.raises(SystemExit):
+            get_argument_parser().parse_args([])

--- a/tests/pdf/test_integration.py
+++ b/tests/pdf/test_integration.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""End-to-end integration test: a PDF directory builds a Faiss index.
+
+This is the test the HTML suite never had: it drives the *real* pipeline a BYOK
+user hits, with only the embedding model mocked.
+
+    doc_type="pdf"
+      -> DocumentProcessor.process() injects the default PDFReader extractor
+      -> real docling converts fixture.pdf to Markdown
+      -> MarkdownNodeParser chunks it
+      -> chunks land in a faiss-backed node list
+
+It asserts that the known marker strings from the source PDF survive all the way
+into the indexed chunks. Skipped when docling models are not cached locally.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+from lightspeed_rag_content import document_processor
+from lightspeed_rag_content.metadata_processor import DefaultMetadataProcessor
+from tests.conftest import RagMockEmbedding
+from tests.pdf.conftest import FIXTURE_MARKERS, requires_docling_models
+
+
+@requires_docling_models
+def test_pdf_directory_builds_faiss_index_with_pdf_text(
+    mocker, tmp_path, fixture_pdf, restore_llama_index_settings
+):
+    """A directory containing a PDF produces indexed chunks holding the PDF text."""
+    # docling resolves its layout/table models from the real Hugging Face cache;
+    # only the sentence-transformers embedding is mocked so no embedding model
+    # download is needed.
+    hf_home = os.environ.get("HF_HOME") or os.path.expanduser("~/.cache/huggingface")
+    mocker.patch.object(document_processor, "HuggingFaceEmbedding", new=RagMockEmbedding)
+
+    docs_dir = tmp_path / "byok"
+    docs_dir.mkdir()
+    shutil.copy(fixture_pdf, docs_dir / "fixture.pdf")
+
+    processor = document_processor.DocumentProcessor(
+        chunk_size=380,
+        chunk_overlap=0,
+        model_name="mock-model",
+        embeddings_model_dir=Path(hf_home),
+        vector_store_type="faiss",
+        doc_type="pdf",
+    )
+    # No file_extractor passed: process() must inject the docling PDFReader itself.
+    processor.process(docs_dir, metadata=DefaultMetadataProcessor(hermetic_build=True))
+
+    good_nodes = processor.db._good_nodes  # pylint: disable=protected-access
+    assert good_nodes, "expected at least one indexed chunk from the PDF"
+
+    node_text = "\n".join(node.text for node in good_nodes)
+    for marker in FIXTURE_MARKERS:
+        assert marker in node_text, f"expected {marker!r} in the indexed chunk text"

--- a/tests/pdf/test_pdf_reader.py
+++ b/tests/pdf/test_pdf_reader.py
@@ -1,0 +1,187 @@
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Tests for PDFReader class.
+
+Two layers of coverage:
+
+* Fast, fully-mocked tests exercise the plumbing around docling (path checks,
+  metadata handling, error wrapping, the R7 empty-output warning).
+* Real, un-mocked tests run the committed fixture PDF through actual docling to
+  prove the conversion genuinely works (skipped when docling models are not
+  cached). The HTML reader has no equivalent, which is why "does it work?" was
+  previously unanswerable from its tests.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from lightspeed_rag_content.pdf.pdf_reader import (
+    EMPTY_OUTPUT_THRESHOLD,
+    PDFReader,
+    convert_pdf_file_to_markdown,
+)
+from tests.pdf.conftest import FIXTURE_HEADING, FIXTURE_MARKERS, requires_docling_models
+
+# A body long enough to clear EMPTY_OUTPUT_THRESHOLD so the success-path tests do
+# not incidentally trip the R7 warning.
+SAMPLE_MARKDOWN = "# Test Title\n\nThis is a sufficiently long body of converted PDF content."
+
+
+@pytest.fixture(name="mock_docling")
+def mock_docling_fixture(mocker):
+    """Mock docling's DocumentConverter inside the pdf_reader module."""
+    mock_document = mocker.MagicMock()
+    mock_document.export_to_markdown.return_value = SAMPLE_MARKDOWN
+
+    mock_result = mocker.MagicMock()
+    mock_result.document = mock_document
+
+    mock_converter = mocker.MagicMock()
+    mock_converter.convert.return_value = mock_result
+
+    mock_converter_class = mocker.patch(
+        "lightspeed_rag_content.pdf.pdf_reader.DocumentConverter",
+        return_value=mock_converter,
+    )
+    return {
+        "converter": mock_converter,
+        "converter_class": mock_converter_class,
+        "result": mock_result,
+        "document": mock_document,
+    }
+
+
+@pytest.fixture(name="pdf_file")
+def pdf_file_fixture(tmp_path):
+    """Create a placeholder PDF file (contents irrelevant; docling is mocked)."""
+    file_path = tmp_path / "test.pdf"
+    file_path.write_bytes(b"%PDF-1.4 placeholder")
+    return file_path
+
+
+class TestPDFReader:
+    """Tests for the PDFReader class (docling mocked)."""
+
+    def test_init_creates_converter(self, mock_docling):
+        """PDFReader initializes a DocumentConverter."""
+        reader = PDFReader()
+        assert reader.converter is not None
+        mock_docling["converter_class"].assert_called_once()
+
+    def test_load_data_file_not_found(self, mock_docling):
+        """FileNotFoundError is raised for a missing file."""
+        reader = PDFReader()
+        with pytest.raises(FileNotFoundError, match="PDF file not found"):
+            reader.load_data(Path("/nonexistent/file.pdf"))
+
+    def test_load_data_successful(self, mock_docling, pdf_file):
+        """A successful conversion yields one Document with markdown and metadata."""
+        reader = PDFReader()
+        documents = reader.load_data(pdf_file)
+
+        assert len(documents) == 1
+        assert documents[0].text == SAMPLE_MARKDOWN
+        assert documents[0].metadata["file_path"] == str(pdf_file)
+        assert documents[0].metadata["file_name"] == "test.pdf"
+        mock_docling["converter"].convert.assert_called_once_with(str(pdf_file))
+
+    def test_load_data_with_extra_info(self, mock_docling, pdf_file):
+        """extra_info is merged into the Document metadata."""
+        reader = PDFReader()
+        documents = reader.load_data(pdf_file, extra_info={"custom_key": "custom_value"})
+
+        assert documents[0].metadata["custom_key"] == "custom_value"
+        assert documents[0].metadata["file_path"] == str(pdf_file)
+
+    def test_load_data_does_not_mutate_extra_info(self, mock_docling, pdf_file):
+        """The caller's extra_info dict is not mutated."""
+        reader = PDFReader()
+        extra_info = {"custom_key": "custom_value"}
+
+        reader.load_data(pdf_file, extra_info=extra_info)
+
+        assert set(extra_info.keys()) == {"custom_key"}
+        assert "file_path" not in extra_info
+        assert "file_name" not in extra_info
+
+    def test_load_data_conversion_error(self, mock_docling, pdf_file):
+        """A docling failure is wrapped in RuntimeError with context."""
+        mock_docling["converter"].convert.side_effect = Exception("Conversion failed")
+        reader = PDFReader()
+
+        with pytest.raises(RuntimeError, match="Failed to convert PDF file"):
+            reader.load_data(pdf_file)
+
+    def test_load_data_warns_on_empty_output(self, mock_docling, pdf_file, caplog):
+        """R7: near-empty output (likely a scanned PDF) triggers a single warning."""
+        mock_docling["document"].export_to_markdown.return_value = "x" * (
+            EMPTY_OUTPUT_THRESHOLD - 1
+        )
+        reader = PDFReader()
+
+        with caplog.at_level(logging.WARNING, logger="lightspeed_rag_content.pdf.pdf_reader"):
+            reader.load_data(pdf_file)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert str(pdf_file) in warnings[0].getMessage()
+
+    def test_load_data_no_warning_on_normal_output(self, mock_docling, pdf_file, caplog):
+        """Sufficiently long output does not trigger the R7 warning."""
+        reader = PDFReader()
+
+        with caplog.at_level(logging.WARNING, logger="lightspeed_rag_content.pdf.pdf_reader"):
+            reader.load_data(pdf_file)
+
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+class TestConvertPdfFileToMarkdown:
+    """Tests for the convert_pdf_file_to_markdown convenience function."""
+
+    def test_successful_conversion(self, mock_docling, pdf_file):
+        """The helper returns the converted markdown text."""
+        assert convert_pdf_file_to_markdown(pdf_file) == SAMPLE_MARKDOWN
+
+    def test_file_not_found(self, mock_docling):
+        """The helper propagates FileNotFoundError for a missing file."""
+        with pytest.raises(FileNotFoundError):
+            convert_pdf_file_to_markdown("/nonexistent/file.pdf")
+
+
+@requires_docling_models
+class TestPDFReaderRealDocling:
+    """Real, un-mocked conversion of the committed fixture PDF through docling."""
+
+    def test_real_conversion_extracts_marker_text(self, fixture_pdf):
+        """The known marker strings survive a real docling conversion."""
+        documents = PDFReader().load_data(fixture_pdf)
+
+        assert len(documents) == 1
+        text = documents[0].text
+        for marker in FIXTURE_MARKERS:
+            assert marker in text, f"expected {marker!r} in converted markdown"
+        assert documents[0].metadata["file_name"] == "fixture.pdf"
+
+    def test_real_conversion_infers_heading(self, fixture_pdf):
+        """docling infers the larger first line as a Markdown heading for chunking."""
+        text = convert_pdf_file_to_markdown(fixture_pdf)
+        assert FIXTURE_HEADING in text
+        # The heading line should carry a Markdown heading prefix so that
+        # MarkdownNodeParser splits on it downstream.
+        heading_line = next(line for line in text.splitlines() if FIXTURE_HEADING in line)
+        assert heading_line.lstrip().startswith("#")

--- a/tests/pdf/test_pdf_reader.py
+++ b/tests/pdf/test_pdf_reader.py
@@ -183,5 +183,6 @@ class TestPDFReaderRealDocling:
         assert FIXTURE_HEADING in text
         # The heading line should carry a Markdown heading prefix so that
         # MarkdownNodeParser splits on it downstream.
-        heading_line = next(line for line in text.splitlines() if FIXTURE_HEADING in line)
-        assert heading_line.lstrip().startswith("#")
+        heading_lines = [line for line in text.splitlines() if FIXTURE_HEADING in line]
+        assert heading_lines, f"expected a line containing {FIXTURE_HEADING!r}"
+        assert heading_lines[0].lstrip().startswith("#")

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -195,3 +195,64 @@ class TestDocumentProcessor:
         doc_processor = document_processor.DocumentProcessor(**mock_processor["params"])
 
         doc_processor.save(mock.sentinel.index, mock.sentinel.output_dir)
+
+
+class TestDefaultFileExtractor:
+    """Tests for the doc_type -> docling reader wiring (no docling models needed)."""
+
+    def test_pdf_returns_pdf_reader(self):
+        """A 'pdf' doc_type maps the .pdf extension to a PDFReader."""
+        from lightspeed_rag_content.pdf import PDFReader
+
+        extractor = document_processor._default_file_extractor("pdf")
+
+        assert extractor is not None
+        assert set(extractor) == {".pdf"}
+        assert isinstance(extractor[".pdf"], PDFReader)
+
+    def test_html_returns_shared_html_reader(self):
+        """An 'html' doc_type maps both HTML extensions to one HTMLReader."""
+        from lightspeed_rag_content.html import HTMLReader
+
+        extractor = document_processor._default_file_extractor("html")
+
+        assert extractor is not None
+        assert set(extractor) == {".html", ".htm"}
+        assert isinstance(extractor[".html"], HTMLReader)
+        assert extractor[".html"] is extractor[".htm"]
+
+    def test_text_returns_none(self):
+        """Plain text and other types need no custom extractor."""
+        assert document_processor._default_file_extractor("text") is None
+
+    def test_process_injects_default_when_extractor_omitted(self, mock_processor, mocker):
+        """process() fills in the doc_type default when no extractor is passed."""
+        reader_mock = mocker.patch.object(document_processor, "SimpleDirectoryReader")
+        reader_mock.return_value.load_data.return_value = []
+        default = mocker.patch.object(
+            document_processor,
+            "_default_file_extractor",
+            return_value=mock.sentinel.default_extractor,
+        )
+
+        doc_processor = document_processor.DocumentProcessor(**mock_processor["params"])
+        doc_processor.process(mock.sentinel.docs_dir, mocker.Mock())
+
+        default.assert_called_once_with("text")
+        assert reader_mock.call_args.kwargs["file_extractor"] is mock.sentinel.default_extractor
+
+    def test_process_keeps_explicit_extractor(self, mock_processor, mocker):
+        """An explicitly supplied extractor is used as-is; the default is not consulted."""
+        reader_mock = mocker.patch.object(document_processor, "SimpleDirectoryReader")
+        reader_mock.return_value.load_data.return_value = []
+        default = mocker.patch.object(document_processor, "_default_file_extractor")
+
+        doc_processor = document_processor.DocumentProcessor(**mock_processor["params"])
+        doc_processor.process(
+            mock.sentinel.docs_dir,
+            mocker.Mock(),
+            file_extractor=mock.sentinel.explicit_extractor,
+        )
+
+        default.assert_not_called()
+        assert reader_mock.call_args.kwargs["file_extractor"] is mock.sentinel.explicit_extractor


### PR DESCRIPTION
## Description

Add native PDF input support to `rag-content` so customers can drop `.pdf`
files into the input directory alongside `.md`, `.txt`, and `.html` and get a
working vector store with no manual pre-conversion. Implements the BYOK PDF
epic (LCORE-2090): LCORE-2091 (implementation) and LCORE-2092 (tests).

- New `lightspeed_rag_content.pdf` package: `PDFReader(BaseReader)` converts PDF
  to Markdown via docling configured for `InputFormat.PDF` (OCR disabled,
  table-structure recognition in `ACCURATE` mode). It warns (rather than failing)
  when conversion yields empty/near-empty Markdown — the likely signature of a
  scanned/image-only PDF. Includes a `convert_pdf_file_to_markdown` helper and a
  `convert` / `batch` CLI.
- `document_processor`: extracted a single `MARKDOWN_COMPATIBLE_DOC_TYPES`
  constant (used at every `doc_type` site so the predicate cannot drift), and —
  when `process()` is called without a `file_extractor` — it now auto-wires the
  docling reader by `doc_type` (`.pdf` -> `PDFReader`, `.html`/`.htm` ->
  `HTMLReader`). Previously the docling readers were reachable only by writing a
  custom script; HTML and PDF now actually reach docling through the shipped
  entrypoints.
- `utils`: `"pdf"` added to the `-dt/--document-type` choices.
- `README`: documents the supported input formats, the standalone PDF CLI, and
  the scanned-PDF limitation.

No new third-party dependencies (docling is already required).

## Type of change

- [x] New feature
- [x] Documentation Update
- [x] Unit tests improvement
- [x] Integration tests improvement

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2090 (epic), LCORE-2092
- Closes # LCORE-2091

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

How to test:

1. Build a vector store from a directory of PDFs and confirm it is produced the
   same way as HTML/Markdown:

   ```bash
   python scripts/generate_embeddings.py -f ./pdfs -o ./out -i my-index \
     -d ./embeddings_model -s llamastack-faiss -t pdf
   ```

2. Convert a single PDF / a directory with the new CLI:

   ```bash
   python -m lightspeed_rag_content.pdf convert -i sample.pdf -o sample.md
   python -m lightspeed_rag_content.pdf batch -i ./pdfs -o ./md
   ```

3. Run the unit + integration tests:

   ```bash
   uv run pytest tests/pdf -v
   ```

Results from this change:

- `uv run pytest tests` — 208 passed (incl. real, un-mocked docling conversions
  of a committed fixture PDF and a full PDF -> docling -> chunk -> Faiss
  integration build). With docling models absent (CI without pre-cache) the
  real-conversion tests skip and coverage is still 93.5% (gate: 90%).
- Lint/type gates: `ruff check src`, CI `mypy src/ scripts/`, `pyright src`,
  `pylint src` (10.00/10), `pydocstyle src scripts tests`, `black --check`,
  radon (avg A) — all green.
- End-to-end (manual): a PDF built into a `llamastack-faiss` store via `-t pdf`
  was consumed by lightspeed-stack as a BYOK source. A query for a fact present
  only in the PDF ("the mascot is a purple penguin named Zephyr") returned that
  fact, with `rag_chunks` attributed to the source PDF — confirming the PDF is
  parsed by docling, embedded, and retrievable end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add PDF input support with automatic PDF→Markdown conversion and CLI commands for single-file and batch conversion.

* **Documentation**
  * Add "Supported Input Formats" section; document document-type options (text/markdown/html/pdf), conversion/chunking behavior, and note scanned/image-only PDFs (OCR disabled; logged warning).

* **Improvements**
  * Route HTML/PDF through Markdown-aware readers for more accurate extraction.

* **Tests**
  * Add unit, integration tests and fixtures covering PDF conversion and CLI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->