### PR TITLE
LCORE-1935: Update rag-tool image labels for CPU and CUDA 12.9

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -116,11 +116,11 @@ USER 1000
 ENTRYPOINT []
 
 LABEL vendor="Red Hat, Inc." \
-    name="lightspeed-core/rag-tool-rhel9" \
-    com.redhat.component="lightspeed-core/rag-tool" \
-    cpe="cpe:/a:redhat:lightspeed_core:0.4::el9" \
-    io.k8s.display-name="Lightspeed RAG Tool" \
-    summary="RAG tool containing embedding model and dependencies needed to generate a vector database." \
-    description="RAG Tool provides a shared codebase for generating vector databases. It serves as the core framework for Lightspeed-related projects (e.g., OpenShift Lightspeed, OpenStack Lightspeed, etc.) to generate their own vector databases that can be used for RAG." \
-    io.k8s.description="RAG Tool provides a shared codebase for generating vector databases. It serves as the core framework for Lightspeed-related projects (e.g., OpenShift Lightspeed, OpenStack Lightspeed, etc.) to generate their own vector databases that can be used for RAG." \
-    io.openshift.tags="lightspeed-core,lightspeed-rag-tool,lightspeed"
+    name="lightspeed-core/rag-tool-cpu-rhel9" \
+    com.redhat.component="lightspeed-core/rag-tool-cpu-rhel9" \
+    cpe="cpe:/a:redhat:lightspeed_core:0.6::el9" \
+    io.k8s.display-name="Lightspeed RAG Tool (CPU)" \
+    summary="RAG tool (CPU) containing embedding model and dependencies needed to generate a vector database." \
+    description="RAG Tool (CPU) provides a shared codebase for generating vector databases. It serves as the core framework for Lightspeed-related projects (e.g., OpenShift Lightspeed, OpenStack Lightspeed, etc.) to generate their own vector databases that can be used for RAG." \
+    io.k8s.description="RAG Tool (CPU) provides a shared codebase for generating vector databases. It serves as the core framework for Lightspeed-related projects (e.g., OpenShift Lightspeed, OpenStack Lightspeed, etc.) to generate their own vector databases that can be used for RAG." \
+    io.openshift.tags="lightspeed-core,lightspeed-rag-tool-cpu,lightspeed"

--- a/Containerfile-cuda
+++ b/Containerfile-cuda
@@ -118,11 +118,11 @@ USER 1000
 ENTRYPOINT []
 
 LABEL vendor="Red Hat, Inc." \
-    name="lightspeed-core/rag-tool-rhel9-cuda" \
-    com.redhat.component="lightspeed-core/rag-tool-cuda" \
-    cpe="cpe:/a:redhat:lightspeed_core:0.4::el9" \
-    io.k8s.display-name="Lightspeed RAG Tool (CUDA)" \
-    summary="RAG tool (CUDA) containing embedding model and dependencies needed to generate a vector database." \
-    description="RAG Tool (CUDA) provides a shared codebase for generating vector databases with CUDA support. It serves as the core framework for Lightspeed-related projects to generate their own vector databases that can be used for RAG." \
-    io.k8s.description="RAG Tool (CUDA) provides a shared codebase for generating vector databases with CUDA support." \
-    io.openshift.tags="lightspeed-core,lightspeed-rag-tool,lightspeed,cuda"
+    name="lightspeed-core/rag-tool-cuda-12.9-rhel9" \
+    com.redhat.component="lightspeed-core/rag-tool-cuda-12.9" \
+    cpe="cpe:/a:redhat:lightspeed_core:0.6::el9" \
+    io.k8s.display-name="Lightspeed RAG Tool (CUDA 12.9)" \
+    summary="RAG tool (CUDA 12.9) containing embedding model and dependencies needed to generate a vector database." \
+    description="RAG Tool (CUDA 12.9) provides a shared codebase for generating vector databases with CUDA support. It serves as the core framework for Lightspeed-related projects to generate their own vector databases that can be used for RAG." \
+    io.k8s.description="RAG Tool (CUDA 12.9) provides a shared codebase for generating vector databases with CUDA support." \
+    io.openshift.tags="lightspeed-core,lightspeed-rag-tool-cuda-12.9,lightspeed,cuda"


### PR DESCRIPTION
## Description

Update rag-tool image labels for CPU and CUDA 12.9 to avoid check-labels failure in Konflux release
```
Error: Component 'rag-content-cpu-0-6' name label ('lightspeed-core/rag-tool-rhel9') does not match expected name ('lightspeed-core/rag-tool-cpu-rhel9')
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-1935
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image naming conventions and metadata labels to better distinguish between CPU and CUDA (12.9) build variants. Revised component identifiers, display names, summary descriptions, and OpenShift tags for consistency. CPE version updated to 0.6 to reflect current versioning standards for container image identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->