### PR TITLE
LCORE-2900: Add __9_DOT_6 suffixes to the RPM repos to avoid confusing Clair

### DIFF
--- a/.konflux/cuda/redhat.repo
+++ b/.konflux/cuda/redhat.repo
@@ -1,4 +1,4 @@
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+[codeready-builder-for-rhel-9-$basearch-eus-rpms__9_DOT_6]
 name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/codeready-builder/os
 enabled = 1
@@ -12,7 +12,7 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-appstream-eus-rpms]
+[rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/appstream/os
 enabled = 1
@@ -26,38 +26,10 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-baseos-eus-rpms]
+[rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/baseos/os
 enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1

--- a/.konflux/cuda/rpms.lock.yaml
+++ b/.konflux/cuda/rpms.lock.yaml
@@ -5,196 +5,196 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/containers-common-1-117.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 158379
     checksum: sha256:5571ade0c71bbf0266315f2584693de7e517df4fe6b0ea0e84381030573b08d9
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 555563
     checksum: sha256:a5c87a7ba8b66f13633cb1634f1678fae4acf5fe16027414117153da8a6c6ed4
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 31089
     checksum: sha256:d4aff59bbd475551f6bb3f9976d77a06d6098c52564dd341e9c7b03d45e24ea9
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.27-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 245064
     checksum: sha256:ee341318d2171cb5475ca806976c87b2ac8c592f883259afeadcc1152dc9ad4d
     name: crun
     evr: 1.27-1.el9_6
     sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 66963
     checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 58189
     checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 92984
     checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 62963
     checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libpq-devel-13.23-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 99035
     checksum: sha256:00a7c684ffa582e4e55543f011dad15a9644d1294e298b3087749afda1b15e6f
     name: libpq-devel
     evr: 13.23-1.el9_6
     sourcerpm: libpq-13.23-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 70971
     checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 38108
     checksum: sha256:06a174486e09cf784296ebead4819a58e8d69e2e312a08f11d8c2f11db2f19ac
     name: ruby
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 42555
     checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3399574
     checksum: sha256:1459413ac7f2cda28f6f7dda2634437c07612949dd6c3619acdaa451af1a6b4b
     name: ruby-libs
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 52554
     checksum: sha256:6043950c6d8a17eca8ede1d3d50d15db2fd4ff7a1c2083faf709ae5d688730cf
     name: rubygem-bigdecimal
     evr: 3.0.0-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 462396
     checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
     evr: 2.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 21967
     checksum: sha256:92ecb6f1a593e5b4bf9feeef800944641399c7d43ec3b5e70b415164fa9ba80b
     name: rubygem-io-console
     evr: 0.5.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 54970
     checksum: sha256:8782b7939343975c585984ebe3f45fc3287b8217823397bc5b14c9ae24be9a91
     name: rubygem-json
     evr: 2.5.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 56684
     checksum: sha256:62155e2d4f3a23b662846ab08680f5cd3bb2d752d4a3096b3d17f4b910f4c725
     name: rubygem-psych
     evr: 3.3.2-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 448009
     checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
     evr: 6.3.4.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 308948
     checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
     evr: 3.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 8844438
     checksum: sha256:b2d58cd41bb5a5353c9b37db78f89fca990ac1189a2e7aa38dec89ab20b4bd93
     name: skopeo
     evr: 2:1.18.1-5.el9_6.1
     sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 50394
     checksum: sha256:01db172d566e090d3a0789d27c3dd7d7151458765b6264784e0fa3d89b132fee
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/y/yajl-2.1.0-25.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 42219
     checksum: sha256:a6becc709b5431b18ccebd844278598f01f05bfd57dc1abfaa1680d5b8edc8ac
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 8718
     checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 38582
     checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 89073
     checksum: sha256:defb5583bcda27004a657df50d385d9884a0d93b14c38725b1141255614dcd0c
     name: shadow-utils-subid
@@ -205,196 +205,196 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 158417
     checksum: sha256:4a45b00847d30c3c804a6184af69e0e11836be975e51960596ce31c459a5d532
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 570685
     checksum: sha256:fcc3972770f19de2ed8030983b30a624aa7a4f93f1f5b70238118ab980375456
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 31924
     checksum: sha256:98a67d3218d5961abaea63a4f7bdfc30ec461ec65bca2347e4d9ea067d7ce4e6
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 261140
     checksum: sha256:2764ddb0593bbf94c10ab8c3cf28d0154115edb8f825539b63d40a28c89737f6
     name: crun
     evr: 1.27-1.el9_6
     sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71022
     checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 58706
     checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 95573
     checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 61278
     checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libpq-devel-13.23-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 100133
     checksum: sha256:001ce9ad00b1f1056e11226d56f1586660c7fbda0260f78b0ca9807699ce57f8
     name: libpq-devel
     evr: 13.23-1.el9_6
     sourcerpm: libpq-13.23-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71992
     checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 38368
     checksum: sha256:d072f7e6ac83e66b3bc5c69f1ab308a8bd345b0ee97d36b5867faf37d81faee4
     name: ruby
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 42555
     checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3449880
     checksum: sha256:52f9f3063895bb14190ec2cd3de8db68b4c1b51e0d1f5cf20364d44c07b51784
     name: ruby-libs
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 52699
     checksum: sha256:fc75becd2aba2639d18b862015eea7e32157de6707b96db634a47c78b5e3a432
     name: rubygem-bigdecimal
     evr: 3.0.0-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 462396
     checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
     evr: 2.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22318
     checksum: sha256:ac62666348a89a487510d75ede0e8bb49a2a8380fab908f8dd4373969b83a195
     name: rubygem-io-console
     evr: 0.5.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 56689
     checksum: sha256:ba1b293ef7a9f08927c128f4e213abc5bebef6b87e3e2a61b41aa7cb0e3a5b34
     name: rubygem-json
     evr: 2.5.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 57061
     checksum: sha256:0089963c883188482e91de9bcc61a43a98bef12c665257c2682ee4b27d0a019f
     name: rubygem-psych
     evr: 3.3.2-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 448009
     checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
     evr: 6.3.4.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 308948
     checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
     evr: 3.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 9785972
     checksum: sha256:07b1e185902de0affdb41d8ba9dbee84bae0916faae901ea783acb6c0063001b
     name: skopeo
     evr: 2:1.18.1-5.el9_6.1
     sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 50387
     checksum: sha256:25a2a6c5cee50c6f4693ee66c782e9644f4ba1fe410c795391afcc07546496e7
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/y/yajl-2.1.0-25.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 42487
     checksum: sha256:f7503f34d5095303db5c57c70c5edb890dab7d0bba5920f3dcc44d7835449555
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 8750
     checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 38224
     checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 90389
     checksum: sha256:342ced93b6ca9b0fd884f990177f7b1e8a6bc35e0bb2a6d4b6684cf8f0062760
     name: shadow-utils-subid

--- a/.konflux/redhat.repo
+++ b/.konflux/redhat.repo
@@ -1,4 +1,4 @@
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+[codeready-builder-for-rhel-9-$basearch-eus-rpms__9_DOT_6]
 name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/codeready-builder/os
 enabled = 1
@@ -12,7 +12,7 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-appstream-eus-rpms]
+[rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/appstream/os
 enabled = 1
@@ -26,38 +26,10 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-baseos-eus-rpms]
+[rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/baseos/os
 enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -5,196 +5,196 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/containers-common-1-117.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 158379
     checksum: sha256:5571ade0c71bbf0266315f2584693de7e517df4fe6b0ea0e84381030573b08d9
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 555563
     checksum: sha256:a5c87a7ba8b66f13633cb1634f1678fae4acf5fe16027414117153da8a6c6ed4
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 31089
     checksum: sha256:d4aff59bbd475551f6bb3f9976d77a06d6098c52564dd341e9c7b03d45e24ea9
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.27-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 245064
     checksum: sha256:ee341318d2171cb5475ca806976c87b2ac8c592f883259afeadcc1152dc9ad4d
     name: crun
     evr: 1.27-1.el9_6
     sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 66963
     checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 58189
     checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 92984
     checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 62963
     checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 70971
     checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 38108
     checksum: sha256:06a174486e09cf784296ebead4819a58e8d69e2e312a08f11d8c2f11db2f19ac
     name: ruby
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 42555
     checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3399574
     checksum: sha256:1459413ac7f2cda28f6f7dda2634437c07612949dd6c3619acdaa451af1a6b4b
     name: ruby-libs
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 52554
     checksum: sha256:6043950c6d8a17eca8ede1d3d50d15db2fd4ff7a1c2083faf709ae5d688730cf
     name: rubygem-bigdecimal
     evr: 3.0.0-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 462396
     checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
     evr: 2.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 21967
     checksum: sha256:92ecb6f1a593e5b4bf9feeef800944641399c7d43ec3b5e70b415164fa9ba80b
     name: rubygem-io-console
     evr: 0.5.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 54970
     checksum: sha256:8782b7939343975c585984ebe3f45fc3287b8217823397bc5b14c9ae24be9a91
     name: rubygem-json
     evr: 2.5.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 56684
     checksum: sha256:62155e2d4f3a23b662846ab08680f5cd3bb2d752d4a3096b3d17f4b910f4c725
     name: rubygem-psych
     evr: 3.3.2-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 448009
     checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
     evr: 6.3.4.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 308948
     checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
     evr: 3.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 8844438
     checksum: sha256:b2d58cd41bb5a5353c9b37db78f89fca990ac1189a2e7aa38dec89ab20b4bd93
     name: skopeo
     evr: 2:1.18.1-5.el9_6.1
     sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 50394
     checksum: sha256:01db172d566e090d3a0789d27c3dd7d7151458765b6264784e0fa3d89b132fee
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/y/yajl-2.1.0-25.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 42219
     checksum: sha256:a6becc709b5431b18ccebd844278598f01f05bfd57dc1abfaa1680d5b8edc8ac
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 8718
     checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 130824
     checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 38582
     checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 89073
     checksum: sha256:defb5583bcda27004a657df50d385d9884a0d93b14c38725b1141255614dcd0c
     name: shadow-utils-subid
@@ -205,196 +205,196 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 158417
     checksum: sha256:4a45b00847d30c3c804a6184af69e0e11836be975e51960596ce31c459a5d532
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 570685
     checksum: sha256:fcc3972770f19de2ed8030983b30a624aa7a4f93f1f5b70238118ab980375456
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 31924
     checksum: sha256:98a67d3218d5961abaea63a4f7bdfc30ec461ec65bca2347e4d9ea067d7ce4e6
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 261140
     checksum: sha256:2764ddb0593bbf94c10ab8c3cf28d0154115edb8f825539b63d40a28c89737f6
     name: crun
     evr: 1.27-1.el9_6
     sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71022
     checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 58706
     checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 95573
     checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 61278
     checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71992
     checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 38368
     checksum: sha256:d072f7e6ac83e66b3bc5c69f1ab308a8bd345b0ee97d36b5867faf37d81faee4
     name: ruby
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 42555
     checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3449880
     checksum: sha256:52f9f3063895bb14190ec2cd3de8db68b4c1b51e0d1f5cf20364d44c07b51784
     name: ruby-libs
     evr: 3.0.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 52699
     checksum: sha256:fc75becd2aba2639d18b862015eea7e32157de6707b96db634a47c78b5e3a432
     name: rubygem-bigdecimal
     evr: 3.0.0-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 462396
     checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
     evr: 2.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22318
     checksum: sha256:ac62666348a89a487510d75ede0e8bb49a2a8380fab908f8dd4373969b83a195
     name: rubygem-io-console
     evr: 0.5.7-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 56689
     checksum: sha256:ba1b293ef7a9f08927c128f4e213abc5bebef6b87e3e2a61b41aa7cb0e3a5b34
     name: rubygem-json
     evr: 2.5.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 57061
     checksum: sha256:0089963c883188482e91de9bcc61a43a98bef12c665257c2682ee4b27d0a019f
     name: rubygem-psych
     evr: 3.3.2-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 448009
     checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
     evr: 6.3.4.1-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 308948
     checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
     evr: 3.2.33-165.el9_6.1
     sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 9785972
     checksum: sha256:07b1e185902de0affdb41d8ba9dbee84bae0916faae901ea783acb6c0063001b
     name: skopeo
     evr: 2:1.18.1-5.el9_6.1
     sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 50387
     checksum: sha256:25a2a6c5cee50c6f4693ee66c782e9644f4ba1fe410c795391afcc07546496e7
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/y/yajl-2.1.0-25.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 42487
     checksum: sha256:f7503f34d5095303db5c57c70c5edb890dab7d0bba5920f3dcc44d7835449555
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 8750
     checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 132888
     checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 38224
     checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 90389
     checksum: sha256:342ced93b6ca9b0fd884f990177f7b1e8a6bc35e0bb2a6d4b6684cf8f0062760
     name: shadow-utils-subid


### PR DESCRIPTION
## Description

Add __9_DOT_6 suffixes to the RPM repos or Clair flags false positive CVEs

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2900
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
