### PR TITLE
LCORE-2900: Add __9_DOT_6 suffixes to the RPM repos to avoid confusing Clair

### DIFF
--- a/redhat.repo
+++ b/redhat.repo
@@ -1,4 +1,4 @@
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+[codeready-builder-for-rhel-9-$basearch-eus-rpms__9_DOT_6]
 name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/codeready-builder/os
 enabled = 1
@@ -12,7 +12,7 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-appstream-eus-rpms]
+[rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/appstream/os
 enabled = 1
@@ -26,38 +26,10 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-baseos-eus-rpms]
+[rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/baseos/os
 enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,707 +5,707 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cargo-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 7744425
     checksum: sha256:5db626d49748f31fb02916c24fa1a7e5759ce7b905ac3e781d42079fba8fa1c4
     name: cargo
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-3.26.5-2.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 7432689
     checksum: sha256:6ac0e5e9a4fd761f8688678ac83580c7eebeacf6c241bd8089d72c4a477b22c3
     name: cmake
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-data-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 2488227
     checksum: sha256:84da65a7b8921f031d15903d91c5967022620f9e96b7493c8ab8024014755ee7
     name: cmake-data
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 12250
     checksum: sha256:1c74969c8a4f21851f5b89f25ac55c689b75bed1318d0435fc3a14a49c39d0e3
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/containers-common-1-117.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 158379
     checksum: sha256:5571ade0c71bbf0266315f2584693de7e517df4fe6b0ea0e84381030573b08d9
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 555563
     checksum: sha256:a5c87a7ba8b66f13633cb1634f1678fae4acf5fe16027414117153da8a6c6ed4
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 31089
     checksum: sha256:d4aff59bbd475551f6bb3f9976d77a06d6098c52564dd341e9c7b03d45e24ea9
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.26-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 242042
-    checksum: sha256:0a3d9f02540dd07366787661c4a252be88da3f217c6b618fb6107c5bd92ae92c
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/crun-1.27-1.el9_6.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 245064
+    checksum: sha256:ee341318d2171cb5475ca806976c87b2ac8c592f883259afeadcc1152dc9ad4d
     name: crun
-    evr: 1.26-1.el9_6
-    sourcerpm: crun-1.26-1.el9_6.src.rpm
+    evr: 1.27-1.el9_6
+    sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 66963
     checksum: sha256:aa95ce8a964df785e349e8ef3baf12eacde4695be51923fecfdbdc1b69b41933
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 58189
     checksum: sha256:2b911ff36ca332c9a5d0f2b2f088b51e9417d2085ec9c44967102f845825ad0f
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 92984
     checksum: sha256:5996291bc8dbb3d32f5d0ac693a4570dba5fe45631d4ca0552696285ff905370
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/git-2.47.3-1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 51846
     checksum: sha256:6d80ba0961c5ddebd612a86790023e8086e5c0ed10bc282b088362b98df2c0a9
     name: git
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3195826
     checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
     name: git-core-doc
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libnet-1.2-7.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 62963
     checksum: sha256:543b0664c576f91ae8f5563f04c2cb3de65ff514d5ed658ac825aa4d98e860dd
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 70971
     checksum: sha256:12fa772c2e3905244fd6cc9971e2592c12a547ac3e4df66f5f0c6ef1e670067d
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 150129
     checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 21344
     checksum: sha256:b4557d853be8048aaefde5c4083c43fa34375e224731e93e584e4e3d5db46ac3
     name: perl-AutoLoader
     evr: 5.74-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-B-1.80-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 184600
     checksum: sha256:f7f82b51c586f075eff5f7fb04b96827425974effee364199844dfdc9b3f5a9b
     name: perl-B
     evr: 1.80-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 22220
     checksum: sha256:d35ff343bd718fbd8531995a8aedb866c6d37fac6a688fcf9a458017781bf058
     name: perl-Class-Struct
     evr: 0.66-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 58773
     checksum: sha256:0ac738aff66419ff8853d2e2b8d2fe231b90de129060ecc0390bca9c6c680e0d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 40515
     checksum: sha256:6eeb8e68cfbd7cca24d6132be8b947de99ab26cdb79d6021e9e6efeb36b67e0b
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 25913
     checksum: sha256:cddb0b2e16a10b80b6b3ffd6409b210aeba404acc589a958f280cac24d12403f
     name: perl-DynaLoader
     evr: 1.47-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 1825541
     checksum: sha256:72c92a12c67d05f9aa7f5670ccb1b743612d8fa946775feada28e199a31db0a9
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Errno-1.30-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 14826
     checksum: sha256:be31dbcae3e58ea4094719bf3882aa3c35599a152341cb48d2aec1aba787d877
     name: perl-Errno
     evr: 1.30-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Fcntl-1.13-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 20270
     checksum: sha256:2dcec56d48812e21c75b6e23a5ee613e7b68aa0d6136e5f9f37bc841592bae97
     name: perl-Fcntl
     evr: 1.13-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Basename-2.85-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 17211
     checksum: sha256:e39dcc13a24d3b5a7ba11288e63b22a055a8e1061743b8a409858d98ebd794e4
     name: perl-File-Basename
     evr: 2.85-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Find-1.37-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 25551
     checksum: sha256:002ec6d107fff6949f1a88965fb31b0a4efe6ce663395ab47e0cb939e3920c08
     name: perl-File-Find
     evr: 1.37-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-stat-1.09-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 17117
     checksum: sha256:b235134c1961e9b57f86bddc02e874607c17c155d2aa5ad78cc3ed9c8fd9c95b
     name: perl-File-stat
     evr: 1.09-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-FileHandle-2.03-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 15452
     checksum: sha256:c2139abdb9b3335f592aa2835ef6d6fcde1e89232eb3d3c5a15f7cc1d0829f8d
     name: perl-FileHandle
     evr: 2.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 15551
     checksum: sha256:49bd8381823d680d17c37f3bebfd97dd92bfbf59e8019f15c7606f41dca02a7d
     name: perl-Getopt-Std
     evr: 1.12-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 38720
     checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
     name: perl-Git
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-1.43-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 90373
     checksum: sha256:eb00f890b53bb5335be0d35994869e8855ad62668ef5199688ab951ffd8c76b6
     name: perl-IO
     evr: 1.43-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 22968
     checksum: sha256:7ea36dcf28da3fc7250eb041ba19f99c87543c0870f5da67da614f5ca8d18b92
     name: perl-IPC-Open3
     evr: 1.21-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 35080
     checksum: sha256:8fd71ba1ada7ab6b0b83400716671139a7adbf01d9bfed881398497170ccb308
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 21832
     checksum: sha256:6a03c4415b13ab8b960e9b1c5440058d006f159c113abdca1c7c4cbec4e2cd58
     name: perl-NDBM_File
     evr: 1.15-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 429301
     checksum: sha256:8f46470e0e2a76d1f534b8d0d607d84a64ebfab3df8347bae2d52d113c8d54eb
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-POSIX-1.94-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 98493
     checksum: sha256:1afecd9468a279bcf9c4e2d7d37f09cc3779f7b869a26ba3d0dcef78f7b9c0af
     name: perl-POSIX
     evr: 1.94-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 94325
     checksum: sha256:5cd800158be7a9ddaf8e9c5d193d10992e01a35c4f438ff072852d194e3a5311
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 76001
     checksum: sha256:5e3592356c1610311f5bf8be4cbc9e35ad04d6b3ba089d70b700d8b70f534635
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 11553
     checksum: sha256:8ec404df551d6cc4750efa34b9897d2288d07a26d49cd3d3d2315584976932b0
     name: perl-SelectSaver
     evr: 1.02-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 59426
     checksum: sha256:f69c6cd2c48606efa7477ef73ef2cb03c07aa02d535f03824dbe966f6235cc88
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 98115
     checksum: sha256:61a7bc7d2a2e3b0c42289927a1ecc7b9f672ce3281be58a59b3b2875e4203457
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Symbol-1.08-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 14061
     checksum: sha256:aa9942be4c837c024c6a0a376b13f9563e16ee8b66631ad6c5ff35cd0124728d
     name: perl-Symbol
     evr: 1.08-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 40577
     checksum: sha256:bfe0d10d4c1028a7929ca213bfd3871f059ea0daeec4c48f3e85d54d77a5a2fc
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-base-2.27-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 16220
     checksum: sha256:0be44f055107893b011ed0e88f39ff202ba451db8a94351ad4472d350c780d0d
     name: perl-base
     evr: 2.27-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-if-0.60.800-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 13876
     checksum: sha256:ae3ce80bee55e1057ed004ec03a0e826b0cdd90ace4c0784ab2f569a2d81d40c
     name: perl-if
     evr: 0.60.800-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 71956
     checksum: sha256:8f17e4683b342e5d0e97406a4c464f6ba7a9b9deaf6e39ff36b5b1459daea162
     name: perl-interpreter
     evr: 4:5.32.1-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-lib-0.65-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 14815
     checksum: sha256:ac5fca3480c9429a1c86b7a781a0713776a75719b9337297f602cfb9cd2eeb12
     name: perl-lib
     evr: 0.65-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-libs-5.32.1-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 2255446
     checksum: sha256:63434fb3f9efb3417bb263c8b9e1590384e7124a094855e82d64655161eaff21
     name: perl-libs
     evr: 4:5.32.1-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-mro-1.23-481.1.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 27780
     checksum: sha256:10e9c630c9628d189ff2d705f280498c83bc407a1fb03b11f4251973b7e46b51
     name: perl-mro
     evr: 1.23-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-overload-1.31-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 46157
     checksum: sha256:f172df7417780cb61b879effe60ce6b7b4399773c46cb9896a5edf2bfba6dbda
     name: perl-overload
     evr: 1.31-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-overloading-0.02-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 12747
     checksum: sha256:4aae487e802df60e1e2d778b264592290ad492078877784771299561d45dfd47
     name: perl-overloading
     evr: 0.02-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-subs-1.03-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 11525
     checksum: sha256:0a7ef4a9a174ab981949d27a4acdc8cec87fd3513e9e607f5869851dc1c74deb
     name: perl-subs
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-vars-1.05-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 12885
     checksum: sha256:5d3c58094c0158b6193d7f4ba7a4bb7ae06a78738393b31255da8b7aadb10e38
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-3.0.7-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 39988
-    checksum: sha256:1b9a250759d6e3e1d54b234bd1b286ac9e60d6a638f3e316c235d42e00340515
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 38108
+    checksum: sha256:06a174486e09cf784296ebead4819a58e8d69e2e312a08f11d8c2f11db2f19ac
     name: ruby
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 43707
-    checksum: sha256:87980d39f679983122cfa4dfc385a10623d07471af660146eb03efaff522acf6
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 42555
+    checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 3414553
-    checksum: sha256:0f68e72ee58afa51b0d3d7f059c27a7fa1c74077a3587ed0bdb5a04ca62f30e5
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 3399574
+    checksum: sha256:1459413ac7f2cda28f6f7dda2634437c07612949dd6c3619acdaa451af1a6b4b
     name: ruby-libs
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 53615
-    checksum: sha256:75a844319d55d48482d467262827f573a70d8d380d624eb7b2cac4e7b78bfaa1
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 52554
+    checksum: sha256:6043950c6d8a17eca8ede1d3d50d15db2fd4ff7a1c2083faf709ae5d688730cf
     name: rubygem-bigdecimal
-    evr: 3.0.0-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 463714
-    checksum: sha256:40a31a95f07540da676a46f96cdf03bb1f16bbc3b50a809cf0c1036dccff5fd9
+    evr: 3.0.0-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 462396
+    checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
-    evr: 2.2.33-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 23769
-    checksum: sha256:ec6e8a35eed8c639e6a4952ceb9e9df3d4184f2d5059da4dd7943b1a005c3f6f
+    evr: 2.2.33-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 21967
+    checksum: sha256:92ecb6f1a593e5b4bf9feeef800944641399c7d43ec3b5e70b415164fa9ba80b
     name: rubygem-io-console
-    evr: 0.5.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 56695
-    checksum: sha256:28548b66c5a05931541c07350ed7fea44a47474a3755fc6590fec56eed84ab59
+    evr: 0.5.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 54970
+    checksum: sha256:8782b7939343975c585984ebe3f45fc3287b8217823397bc5b14c9ae24be9a91
     name: rubygem-json
-    evr: 2.5.1-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 57944
-    checksum: sha256:f001209c79aa6288fd73f6f2ad729c0ca4236cd8f6f5c6fca5ebde2f1b479055
+    evr: 2.5.1-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 56684
+    checksum: sha256:62155e2d4f3a23b662846ab08680f5cd3bb2d752d4a3096b3d17f4b910f4c725
     name: rubygem-psych
-    evr: 3.3.2-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 447643
-    checksum: sha256:e10f7a41570c647f3fdfff59cf160036e80e48fc027a92dd624e37a31fda5766
+    evr: 3.3.2-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 448009
+    checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
-    evr: 6.3.4.1-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 310195
-    checksum: sha256:03ae5e148b2be4c5a0fac3cb3cbfe3895f56cf67aa9212f6f28665589caf10e6
+    evr: 6.3.4.1-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 308948
+    checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
-    evr: 3.2.33-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+    evr: 3.2.33-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rust-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 26093725
     checksum: sha256:5be9185a7d684022bc0686049c22ef901c4df6dce2822bdec16a1a47c46b6861
     name: rust
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rust-std-static-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 39259196
     checksum: sha256:5889bced81144c4ea201085e5bfd040300c56048e5d7987e9eb69d4d252f87bf
     name: rust-std-static
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-3.el9_6.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 8833242
-    checksum: sha256:9c66bec7522e6970c21dc251e2a1b615bf118741bd62d4d7eefab191a8810015
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    size: 8844438
+    checksum: sha256:b2d58cd41bb5a5353c9b37db78f89fca990ac1189a2e7aa38dec89ab20b4bd93
     name: skopeo
-    evr: 2:1.18.1-3.el9_6
-    sourcerpm: skopeo-1.18.1-3.el9_6.src.rpm
+    evr: 2:1.18.1-5.el9_6.1
+    sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 50394
     checksum: sha256:01db172d566e090d3a0789d27c3dd7d7151458765b6264784e0fa3d89b132fee
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/y/yajl-2.1.0-25.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 42219
     checksum: sha256:a6becc709b5431b18ccebd844278598f01f05bfd57dc1abfaa1680d5b8edc8ac
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 8718
     checksum: sha256:ee202d37528745e6367791304c4f04af4a84bc9df2027234900186a8bff858f7
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 130824
     checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 414358
     checksum: sha256:549675f7fd1d4538ddc3b1e15910449c711af664d6d73fbbb7f7addb7e7e9634
     name: ncurses
     evr: 6.2-10.20210508.el9_6.2
     sourcerpm: ncurses-6.2-10.20210508.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 38582
     checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 89073
     checksum: sha256:defb5583bcda27004a657df50d385d9884a0d93b14c38725b1141255614dcd0c
     name: shadow-utils-subid
@@ -716,707 +716,707 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cargo-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 8292467
     checksum: sha256:7dd011cd79a635654ade4e3186c5f7545d692de81157d1ce1d42656eaa6993b2
     name: cargo
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-3.26.5-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 9159462
     checksum: sha256:f553370cb02b87e7388697468256556e765b102c2fcb56be6bc250cb2351e8ad
     name: cmake
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-data-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 2488227
     checksum: sha256:84da65a7b8921f031d15903d91c5967022620f9e96b7493c8ab8024014755ee7
     name: cmake-data
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 12250
     checksum: sha256:1c74969c8a4f21851f5b89f25ac55c689b75bed1318d0435fc3a14a49c39d0e3
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 158417
     checksum: sha256:4a45b00847d30c3c804a6184af69e0e11836be975e51960596ce31c459a5d532
     name: containers-common
     evr: 2:1-117.el9_6
     sourcerpm: containers-common-1-117.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 570685
     checksum: sha256:fcc3972770f19de2ed8030983b30a624aa7a4f93f1f5b70238118ab980375456
     name: criu
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/criu-libs-3.19-1.2.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 31924
     checksum: sha256:98a67d3218d5961abaea63a4f7bdfc30ec461ec65bca2347e4d9ea067d7ce4e6
     name: criu-libs
     evr: 3.19-1.2.el9_6
     sourcerpm: criu-3.19-1.2.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.26-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 258553
-    checksum: sha256:b3cda6b34c737ffba190c553029ad65b492ce85665463814f65a63e1922f6362
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 261140
+    checksum: sha256:2764ddb0593bbf94c10ab8c3cf28d0154115edb8f825539b63d40a28c89737f6
     name: crun
-    evr: 1.26-1.el9_6
-    sourcerpm: crun-1.26-1.el9_6.src.rpm
+    evr: 1.27-1.el9_6
+    sourcerpm: crun-1.27-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.14-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71022
     checksum: sha256:884e4034c930e0305d2402da2bdc1eac5a91295da06e554b75c1c9a4529ddbc2
     name: fuse-overlayfs
     evr: 1.14-1.el9
     sourcerpm: fuse-overlayfs-1.14-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 58706
     checksum: sha256:4674b4ee6150c8f8be01a028a471c209a6be7c0cf78e9450cf28fb01eaed9ea2
     name: fuse3
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/f/fuse3-libs-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 95573
     checksum: sha256:945e1d95edbce9c7dba52e9317d4564381efa5a1ba48d4bd49a58c85e47cd717
     name: fuse3-libs
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/git-2.47.3-1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 51883
     checksum: sha256:5097b6a0540e33dd02d581109cf1b10fcc736975c330208fae148efacb13b649
     name: git
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/g/git-core-doc-2.47.3-1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3195826
     checksum: sha256:0008ecada894ff2a51c43f868b7727baae3836911b541a613769d2e93d501442
     name: git-core-doc
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libnet-1.2-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 61278
     checksum: sha256:738b9a7ab78c149487e349d90c384b59031d5763ba687a6b58a4f853671af86b
     name: libnet
     evr: 1.2-7.el9
     sourcerpm: libnet-1.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libslirp-4.4.0-8.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 71992
     checksum: sha256:9bd269ec50504f997683e963481f870bb937c3cfdb54a057e9acca67bf2b7631
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 154427
     checksum: sha256:e1fab39251239ccaad2fb4dbe6c55ec1ae60f76d4ae81582b06e6a58e30879b2
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 21344
     checksum: sha256:b4557d853be8048aaefde5c4083c43fa34375e224731e93e584e4e3d5db46ac3
     name: perl-AutoLoader
     evr: 5.74-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-B-1.80-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 183818
     checksum: sha256:8b5a3d27f69cce8dd4c237510c2aaa2d01b3e884452e5da467d9c41015372c6a
     name: perl-B
     evr: 1.80-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22220
     checksum: sha256:d35ff343bd718fbd8531995a8aedb866c6d37fac6a688fcf9a458017781bf058
     name: perl-Class-Struct
     evr: 0.66-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 59910
     checksum: sha256:6cd912e640cbc8785e33dae9cf07561509491a0ec76a81c01d6b7a77ad08668d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 40274
     checksum: sha256:2a6b21a144ae1d060e51ee2b6328c5dd1a646f429da160f386c2eb420b1220b4
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 25958
     checksum: sha256:937d31c9fc324bfa7434e8455cf1828afd46e4502f661566a7286853d8d46bf1
     name: perl-DynaLoader
     evr: 1.47-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 1802386
     checksum: sha256:d05248697e48928be004ed4c683b04966aa452ae1e2bd81f650c6de108b46956
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 14862
     checksum: sha256:9c03ad1166d9f8e6d2affb52185f59d625468d160f7c749e3d53a844d5129d4c
     name: perl-Errno
     evr: 1.30-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 20397
     checksum: sha256:72587bf21b26885361ec991d153e1b4db26e9b117c1c70b92cc2891cecae4575
     name: perl-Fcntl
     evr: 1.13-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 17211
     checksum: sha256:e39dcc13a24d3b5a7ba11288e63b22a055a8e1061743b8a409858d98ebd794e4
     name: perl-File-Basename
     evr: 2.85-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Find-1.37-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 25551
     checksum: sha256:002ec6d107fff6949f1a88965fb31b0a4efe6ce663395ab47e0cb939e3920c08
     name: perl-File-Find
     evr: 1.37-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 17117
     checksum: sha256:b235134c1961e9b57f86bddc02e874607c17c155d2aa5ad78cc3ed9c8fd9c95b
     name: perl-File-stat
     evr: 1.09-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 15452
     checksum: sha256:c2139abdb9b3335f592aa2835ef6d6fcde1e89232eb3d3c5a15f7cc1d0829f8d
     name: perl-FileHandle
     evr: 2.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 15551
     checksum: sha256:49bd8381823d680d17c37f3bebfd97dd92bfbf59e8019f15c7606f41dca02a7d
     name: perl-Getopt-Std
     evr: 1.12-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Git-2.47.3-1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 38720
     checksum: sha256:d0b4a24233ba8a6eb0966b3b6d8d52dfc5c33577fc8033e693f9aa181f3e2330
     name: perl-Git
     evr: 2.47.3-1.el9_6
     sourcerpm: git-2.47.3-1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 90423
     checksum: sha256:e29f5b38c643882a6b9ab9ddbb77bdd476d1a55e3ab649e886e99dd726b3c822
     name: perl-IO
     evr: 1.43-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22968
     checksum: sha256:7ea36dcf28da3fc7250eb041ba19f99c87543c0870f5da67da614f5ca8d18b92
     name: perl-IPC-Open3
     evr: 1.21-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 35058
     checksum: sha256:3ae8affe13cc15cfaee1c6dd078ada14891dde5dca263927a9b5ed87f241d2c0
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22193
     checksum: sha256:1c340352c349ee46ad071436947a1fa1bd353e984fb3d8d3328f2c287c8c5421
     name: perl-NDBM_File
     evr: 1.15-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 428188
     checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 98084
     checksum: sha256:434ef22a697f38f3dda351db9ab427e02e7a1220b2dcbc3046087bd9129b742e
     name: perl-POSIX
     evr: 1.94-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 94564
     checksum: sha256:0647785b169c4bbdc65adf06d28981ce7fd1c9f93aecaa4e53a4515a21ebbf81
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 77262
     checksum: sha256:7ce874bde7d9ad15abf70a3b7edbab77548eb2eb8b529c1e48b2426ee7f948f9
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 11553
     checksum: sha256:8ec404df551d6cc4750efa34b9897d2288d07a26d49cd3d3d2315584976932b0
     name: perl-SelectSaver
     evr: 1.02-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 59776
     checksum: sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 100335
     checksum: sha256:0097fdb40a1f83e56d5bf91160c07151b7cdd64f829fc0e328cdf3b43c2b4fa6
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 14061
     checksum: sha256:aa9942be4c837c024c6a0a376b13f9563e16ee8b66631ad6c5ff35cd0124728d
     name: perl-Symbol
     evr: 1.08-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 41023
     checksum: sha256:5ff266e740a93344e1ce2913f4bec0f38cfdf721841e6762d85ac21d716ee9f8
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-base-2.27-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 16220
     checksum: sha256:0be44f055107893b011ed0e88f39ff202ba451db8a94351ad4472d350c780d0d
     name: perl-base
     evr: 2.27-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 13876
     checksum: sha256:ae3ce80bee55e1057ed004ec03a0e826b0cdd90ace4c0784ab2f569a2d81d40c
     name: perl-if
     evr: 0.60.800-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 72173
     checksum: sha256:92959263a20ad89d33bc92826cdfed32f507652ff08d0c18b50b604fa5f9f594
     name: perl-interpreter
     evr: 4:5.32.1-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-lib-0.65-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 14847
     checksum: sha256:badc59793f32fa6e98fd705101af0b879720db5e0811b46755640d3d64165715
     name: perl-lib
     evr: 0.65-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 2303689
     checksum: sha256:aa0e9b31c82b50de7ace1b7e4b85a26ac9572cc77b8ded88866c06915748ccd7
     name: perl-libs
     evr: 4:5.32.1-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 28410
     checksum: sha256:4ed671f36290bc6c15f37d550f67ce33ced1c27a3e2ea24f0a37038d45d1805a
     name: perl-mro
     evr: 1.23-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 46157
     checksum: sha256:f172df7417780cb61b879effe60ce6b7b4399773c46cb9896a5edf2bfba6dbda
     name: perl-overload
     evr: 1.31-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 12747
     checksum: sha256:4aae487e802df60e1e2d778b264592290ad492078877784771299561d45dfd47
     name: perl-overloading
     evr: 0.02-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 11525
     checksum: sha256:0a7ef4a9a174ab981949d27a4acdc8cec87fd3513e9e607f5869851dc1c74deb
     name: perl-subs
     evr: 1.03-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.1.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 12885
     checksum: sha256:5d3c58094c0158b6193d7f4ba7a4bb7ae06a78738393b31255da8b7aadb10e38
     name: perl-vars
     evr: 1.05-481.1.el9_6
     sourcerpm: perl-5.32.1-481.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-pip-23.2.1-4.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 3377244
     checksum: sha256:d7fddc3a02b3cba2256034e3ed61378dc37bd6155f91f5feb7560c9ffeb5230e
     name: python3.12-pip
     evr: 23.2.1-4.el9
     sourcerpm: python3.12-pip-23.2.1-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python3.12-setuptools-68.2.2-5.el9_6.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 1654905
     checksum: sha256:6a7ea24faa6a5f2686b5e5b103a09f63b929b9bef70f1392dfea4ec5ef57c819
     name: python3.12-setuptools
     evr: 68.2.2-5.el9_6
     sourcerpm: python3.12-setuptools-68.2.2-5.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-3.0.7-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 40261
-    checksum: sha256:3efe1d022b580d04b9a321990740bcc18b04ce1288a7c3985d74582e24e564e5
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-3.0.7-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 38368
+    checksum: sha256:d072f7e6ac83e66b3bc5c69f1ab308a8bd345b0ee97d36b5867faf37d81faee4
     name: ruby
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 43707
-    checksum: sha256:87980d39f679983122cfa4dfc385a10623d07471af660146eb03efaff522acf6
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 42555
+    checksum: sha256:6d19952906afa04807458bb78809bf988393a4522addd0dd570adb13c2d88c9f
     name: ruby-default-gems
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3461571
-    checksum: sha256:3e5da47b7d1e12b6d51a11af40f239f7bf7fcd148670efa25c1beb49431e6e98
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 3449880
+    checksum: sha256:52f9f3063895bb14190ec2cd3de8db68b4c1b51e0d1f5cf20364d44c07b51784
     name: ruby-libs
-    evr: 3.0.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 53767
-    checksum: sha256:4b44966556dcd4488deb754f152d19b9a3c38c827cb98a13593cf6b36b8441a2
+    evr: 3.0.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 52699
+    checksum: sha256:fc75becd2aba2639d18b862015eea7e32157de6707b96db634a47c78b5e3a432
     name: rubygem-bigdecimal
-    evr: 3.0.0-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 463714
-    checksum: sha256:40a31a95f07540da676a46f96cdf03bb1f16bbc3b50a809cf0c1036dccff5fd9
+    evr: 3.0.0-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 462396
+    checksum: sha256:9df3fe202f75e9697417373cf7c5185824d40c3e9edd1287d0a45baa9173c59f
     name: rubygem-bundler
-    evr: 2.2.33-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 24121
-    checksum: sha256:ad35f8e56ede1cdd9d2df7734c43288cfcd7ad4b2b891ef89b3c2f92e6bdcd08
+    evr: 2.2.33-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 22318
+    checksum: sha256:ac62666348a89a487510d75ede0e8bb49a2a8380fab908f8dd4373969b83a195
     name: rubygem-io-console
-    evr: 0.5.7-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 57752
-    checksum: sha256:ef59f0eeb3eac1836d6cfe9df4c4df19b15332a07a9aa52e20c319d299618f8e
+    evr: 0.5.7-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 56689
+    checksum: sha256:ba1b293ef7a9f08927c128f4e213abc5bebef6b87e3e2a61b41aa7cb0e3a5b34
     name: rubygem-json
-    evr: 2.5.1-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 58369
-    checksum: sha256:2d8d5482edb3d7d81f948d3c03c7eb74c523911f782a6ea65cd00658089328d4
+    evr: 2.5.1-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 57061
+    checksum: sha256:0089963c883188482e91de9bcc61a43a98bef12c665257c2682ee4b27d0a019f
     name: rubygem-psych
-    evr: 3.3.2-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 447643
-    checksum: sha256:e10f7a41570c647f3fdfff59cf160036e80e48fc027a92dd624e37a31fda5766
+    evr: 3.3.2-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 448009
+    checksum: sha256:e41a41d8476e6a2c93fafd9e2df55aac00660add7c77999e9fad7716cfa0d458
     name: rubygem-rdoc
-    evr: 6.3.4.1-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_5.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 310195
-    checksum: sha256:03ae5e148b2be4c5a0fac3cb3cbfe3895f56cf67aa9212f6f28665589caf10e6
+    evr: 6.3.4.1-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_6.1.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 308948
+    checksum: sha256:36bda8021d0d7cc7518afc880461d5f3b8c8fd2a884fb1aceaf05ad97edab2c2
     name: rubygems
-    evr: 3.2.33-165.el9_5
-    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+    evr: 3.2.33-165.el9_6.1
+    sourcerpm: ruby-3.0.7-165.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rust-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 28050444
     checksum: sha256:9ba3c53fd811af2f294e31360d75e33e4cb89893130c7b3fe0c6191e20a09f3e
     name: rust
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rust-std-static-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 41211472
     checksum: sha256:73bb90884432e2b43758f1043f107a570b5d54b38f17d5d0af51bac103ceb4f5
     name: rust-std-static
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-3.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 9803426
-    checksum: sha256:19a318d9e0057d9738a716b4089771066cf1a8397781b57013505bfde80f4805
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/skopeo-1.18.1-5.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    size: 9785972
+    checksum: sha256:07b1e185902de0affdb41d8ba9dbee84bae0916faae901ea783acb6c0063001b
     name: skopeo
-    evr: 2:1.18.1-3.el9_6
-    sourcerpm: skopeo-1.18.1-3.el9_6.src.rpm
+    evr: 2:1.18.1-5.el9_6.1
+    sourcerpm: skopeo-1.18.1-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/s/slirp4netns-1.3.2-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 50387
     checksum: sha256:25a2a6c5cee50c6f4693ee66c782e9644f4ba1fe410c795391afcc07546496e7
     name: slirp4netns
     evr: 1.3.2-1.el9
     sourcerpm: slirp4netns-1.3.2-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/y/yajl-2.1.0-25.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 42487
     checksum: sha256:f7503f34d5095303db5c57c70c5edb890dab7d0bba5920f3dcc44d7835449555
     name: yajl
     evr: 2.1.0-25.el9
     sourcerpm: yajl-2.1.0-25.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/f/fuse-common-3.10.2-9.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 8750
     checksum: sha256:548265cbee787fa659bc79c07e15a12007f39eb70e905bf660ec488f0bb8820f
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 132888
     checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 416227
     checksum: sha256:4f1dbaed64ecaf650d47613b86ea787d92b7fad23e8a75e8b86cc436ee949f49
     name: ncurses
     evr: 6.2-10.20210508.el9_6.2
     sourcerpm: ncurses-6.2-10.20210508.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 38224
     checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-12.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 90389
     checksum: sha256:342ced93b6ca9b0fd884f990177f7b1e8a6bc35e0bb2a6d4b6684cf8f0062760
     name: shadow-utils-subid


### PR DESCRIPTION
## Description

Add __9_DOT_6 suffixes to the RPM repos to avoid Clair flagging false positive CVEs from wrong RHEL version repos.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2900
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
