### PR TITLE
LCORE-3013: fixed the rag-content integration test [main]

### DIFF
--- a/.tekton/integration-tests/pipeline/rag-content-0-7-integration-test.yaml
+++ b/.tekton/integration-tests/pipeline/rag-content-0-7-integration-test.yaml
@@ -71,9 +71,9 @@ spec:
                 > $(step.results.cuda-image.path)
               echo -n "$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .containerImage // ""' <<< "$SNAPSHOT")" \
                 > $(step.results.lightspeed-stack-image.path)
-              echo -n "$(jq -r '.components[0].source.git.revision // "main"' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-7") | .source.git.revision // "main"' <<< "$SNAPSHOT")" \
                 > $(step.results.commit.path)
-              echo -n "$(jq -r '.components[0].source.git.url // "https://github.com/lightspeed-core/rag-content.git"' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-7") | .source.git.url // "https://github.com/lightspeed-core/rag-content.git"' <<< "$SNAPSHOT")" \
                 > $(step.results.repo-url.path)
               echo "CPU image:              $(cat $(step.results.cpu-image.path))"
               echo "CUDA image:             $(cat $(step.results.cuda-image.path))"


### PR DESCRIPTION
## Description

**Problem**: The pipeline uses `components[0]` to get the repo URL and revision. When triggered by a lightspeed-stack build (via `component_lightspeed-stack-0-X` context), the first component in the Snapshot is lightspeed-stack, not rag-content — so it clones the wrong repo.

**Fix**: Look up `rag-content-cpu-0-X` by name instead of using array position.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-3013
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
