### PR TITLE
Fix a ruff check violation "RUF036 [*] `None` not at the end of the type union." [release/0.5]

### DIFF
--- a/src/lightspeed_rag_content/document_processor.py
+++ b/src/lightspeed_rag_content/document_processor.py
@@ -116,7 +116,7 @@ class _BaseDB:
 
 class _LlamaIndexDB(_BaseDB):
     def __init__(self, config: _Config):
-        vector_store: None | BasePydanticVectorStore = None
+        vector_store: BasePydanticVectorStore | None = None
 
         assert config.vector_store_type in ("faiss", "postgres")  # noqa: S101
         super().__init__(config)


### PR DESCRIPTION
## Description

Fixed a ruff check violation "RUF036 [*] `None` not at the end of the type union."

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
