### PR TITLE
Migrate the integration test to Lightspeed Core 0.8 [main]

### DIFF
--- a/.tekton/integration-tests/pipeline/rag-content-0-8-integration-test.yaml
+++ b/.tekton/integration-tests/pipeline/rag-content-0-8-integration-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: rag-content-0-7-integration-tests-pipeline
+  name: rag-content-0-8-integration-tests-pipeline
 spec:
   description: |
     Integration test: validates that rag-content images (CPU and CUDA) can
@@ -11,12 +11,12 @@ spec:
     multi-platform controller. Tests all combinations: 2 images × 2 arches.
   params:
     - name: SNAPSHOT
-      description: 'JSON string with the application snapshot (contains rag-content-cpu-0-7, rag-content-cuda-12-9-0-7, and lightspeed-stack-0-7 components).'
+      description: 'JSON string with the application snapshot (contains rag-content-cpu-0-8, rag-content-cuda-12-9-0-8, and lightspeed-stack-0-8 components).'
       default: '{"components": [{"name":"rag-tool", "containerImage": "quay.io/example/rag-content:latest"}]}'
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'rag-content-0-7-e2e-tests'
+      default: 'rag-content-0-8-e2e-tests'
     - name: platforms
       description: VM platforms on which to run the integration test
       type: array
@@ -65,15 +65,15 @@ spec:
                 type: string
             script: |
               dnf -y install jq
-              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-7") | .containerImage // ""' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-8") | .containerImage // ""' <<< "$SNAPSHOT")" \
                 > $(step.results.cpu-image.path)
-              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cuda-12-9-0-7") | .containerImage // ""' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cuda-12-9-0-8") | .containerImage // ""' <<< "$SNAPSHOT")" \
                 > $(step.results.cuda-image.path)
-              echo -n "$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .containerImage // ""' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "lightspeed-stack-0-8") | .containerImage // ""' <<< "$SNAPSHOT")" \
                 > $(step.results.lightspeed-stack-image.path)
-              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-7") | .source.git.revision // "main"' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-8") | .source.git.revision // "main"' <<< "$SNAPSHOT")" \
                 > $(step.results.commit.path)
-              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-7") | .source.git.url // "https://github.com/lightspeed-core/rag-content.git"' <<< "$SNAPSHOT")" \
+              echo -n "$(jq -r '.components[] | select(.name == "rag-content-cpu-0-8") | .source.git.url // "https://github.com/lightspeed-core/rag-content.git"' <<< "$SNAPSHOT")" \
                 > $(step.results.repo-url.path)
               echo "CPU image:              $(cat $(step.results.cpu-image.path))"
               echo "CUDA image:             $(cat $(step.results.cuda-image.path))"


### PR DESCRIPTION
## Description

Migrate the integration test to Lightspeed Core 0.8

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # 
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated integration testing to target the rag-content 0-8 CPU, CUDA, and lightspeed-stack components.
  * Updated pipeline metadata, snapshot references, and end-to-end test naming for the 0-8 release.
  * Preserved existing fallback behavior for snapshot extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->