### PR TITLE
Add the RHELAI RPM repo as used in the AIPCC base image [release/0.7]

### DIFF
--- a/.konflux/build-args-konflux.conf
+++ b/.konflux/build-args-konflux.conf
@@ -1,4 +1,4 @@
-BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1786384816
+BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1786556387
 BUILDER_DNF_COMMAND=dnf
-RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1786384816
+RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-1786556387
 RUNTIME_DNF_COMMAND=dnf

--- a/.konflux/cuda/build-args-konflux.conf
+++ b/.konflux/cuda/build-args-konflux.conf
@@ -1,4 +1,4 @@
-BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1786385265
+BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1786555851
 BUILDER_DNF_COMMAND=dnf
-RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1786385265
+RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.5.0-1786555851
 RUNTIME_DNF_COMMAND=dnf

--- a/.konflux/cuda/redhat.repo
+++ b/.konflux/cuda/redhat.repo
@@ -11,7 +11,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
@@ -26,7 +25,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
@@ -41,4 +39,17 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
+
+[rhelai-3.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.5/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT

--- a/.konflux/cuda/rpms.in.yaml
+++ b/.konflux/cuda/rpms.in.yaml
@@ -16,6 +16,7 @@ packages:
 upgradePackages:
   [
     libgcrypt,
+    thrift,
   ]
 moduleEnable:
   - "ruby:3.3"

--- a/.konflux/cuda/rpms.lock.yaml
+++ b/.konflux/cuda/rpms.lock.yaml
@@ -186,13 +186,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-    size: 463379
-    checksum: sha256:ca4492eea2902aa597ddc8f9859f5312f2d4e9beafe94b188c014df6f8bbc91f
-    name: libgcrypt
-    evr: 1.10.0-11.el9_6.1
-    sourcerpm: libgcrypt-1.10.0-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 38582
@@ -209,10 +202,10 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d5bffd551225475e0900ac34e8804498e56326d226f4903dd540e0a7c9324e72-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979-modules.yaml.gz
     repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 44782
-    checksum: sha256:d5bffd551225475e0900ac34e8804498e56326d226f4903dd540e0a7c9324e72
+    checksum: sha256:d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
@@ -397,13 +390,6 @@ arches:
     name: fuse-common
     evr: 3.10.2-9.el9
     sourcerpm: fuse3-3.10.2-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-    size: 517430
-    checksum: sha256:57bb13f2d7b44dafd7ecd20924a5be434223c567ddf5322c8c2d89c800df6d0e
-    name: libgcrypt
-    evr: 1.10.0-11.el9_6.1
-    sourcerpm: libgcrypt-1.10.0-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 38224
@@ -420,7 +406,7 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/7de128fdda518554daf65fbc82e2da9800bbaf8b9af102844344250625c55583-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 43586
-    checksum: sha256:7de128fdda518554daf65fbc82e2da9800bbaf8b9af102844344250625c55583
+    checksum: sha256:d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2

--- a/.konflux/redhat.repo
+++ b/.konflux/redhat.repo
@@ -11,7 +11,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
@@ -26,7 +25,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
@@ -41,4 +39,17 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
+
+[rhelai-3.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.5/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT

--- a/.konflux/rpms.in.yaml
+++ b/.konflux/rpms.in.yaml
@@ -23,6 +23,7 @@ packages:
 upgradePackages:
   [
     libgcrypt,
+    thrift,
   ]
 moduleEnable:
   - "ruby:3.3"

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -186,13 +186,6 @@ arches:
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9_6.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-    size: 463379
-    checksum: sha256:ca4492eea2902aa597ddc8f9859f5312f2d4e9beafe94b188c014df6f8bbc91f
-    name: libgcrypt
-    evr: 1.10.0-11.el9_6.1
-    sourcerpm: libgcrypt-1.10.0-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 38582
@@ -209,10 +202,10 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d5bffd551225475e0900ac34e8804498e56326d226f4903dd540e0a7c9324e72-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979-modules.yaml.gz
     repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 44782
-    checksum: sha256:d5bffd551225475e0900ac34e8804498e56326d226f4903dd540e0a7c9324e72
+    checksum: sha256:d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
@@ -397,13 +390,6 @@ arches:
     name: kmod
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-    size: 517430
-    checksum: sha256:57bb13f2d7b44dafd7ecd20924a5be434223c567ddf5322c8c2d89c800df6d0e
-    name: libgcrypt
-    evr: 1.10.0-11.el9_6.1
-    sourcerpm: libgcrypt-1.10.0-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 38224
@@ -420,7 +406,7 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/7de128fdda518554daf65fbc82e2da9800bbaf8b9af102844344250625c55583-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 43586
-    checksum: sha256:7de128fdda518554daf65fbc82e2da9800bbaf8b9af102844344250625c55583
+    checksum: sha256:d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2


### PR DESCRIPTION
## Description

Add the RHELAI RPM repo as used in the AIPCC base image [release/0.7]

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
