### PR TITLE
Add the RHELAI RPM repo as used in the AIPCC base image [main]

### DIFF
--- a/.konflux/cuda/redhat.repo
+++ b/.konflux/cuda/redhat.repo
@@ -11,7 +11,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
@@ -26,7 +25,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
@@ -41,4 +39,17 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
+
+[rhelai-3.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.5/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT

--- a/.konflux/cuda/rpms.in.yaml
+++ b/.konflux/cuda/rpms.in.yaml
@@ -13,6 +13,10 @@ packages:
     libpq-devel,
     skopeo,
   ]
+upgradePackages:
+  [
+    thrift,
+  ]
 moduleEnable:
   - "ruby:3.3"
 contentOrigin:

--- a/.konflux/cuda/rpms.lock.yaml
+++ b/.konflux/cuda/rpms.lock.yaml
@@ -202,10 +202,10 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/baafe17b13aae4488f9c1e8f9b474223c42026f160598c05c186945deb91f1c7-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979-modules.yaml.gz
     repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 44782
-    checksum: sha256:baafe17b13aae4488f9c1e8f9b474223c42026f160598c05c186945deb91f1c7
+    checksum: sha256:d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
@@ -406,7 +406,7 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/ea47724085e35131c2c8aca52dd0a74433a23c05c770b05c888c496a882bc9db-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 43586
-    checksum: sha256:ea47724085e35131c2c8aca52dd0a74433a23c05c770b05c888c496a882bc9db
+    checksum: sha256:d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2

--- a/.konflux/redhat.repo
+++ b/.konflux/redhat.repo
@@ -11,7 +11,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
@@ -26,7 +25,6 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
 
 [rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
@@ -41,4 +39,17 @@ metadata_expire = 86400
 enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
-excludepkgs=*.i686
+
+[rhelai-3.5-for-rhel-9-$basearch-rpms]
+name = Red Hat Enterprise Linux AI (3.5) for RHEL 9 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhelai/3.5/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT

--- a/.konflux/rpms.in.yaml
+++ b/.konflux/rpms.in.yaml
@@ -20,6 +20,10 @@ packages:
     openexr-libs,
     skopeo,
   ]
+upgradePackages:
+  [
+    thrift,
+  ]
 moduleEnable:
   - "ruby:3.3"
 contentOrigin:

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -202,10 +202,10 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/baafe17b13aae4488f9c1e8f9b474223c42026f160598c05c186945deb91f1c7-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/repodata/d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979-modules.yaml.gz
     repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 44782
-    checksum: sha256:baafe17b13aae4488f9c1e8f9b474223c42026f160598c05c186945deb91f1c7
+    checksum: sha256:d67d02abee3a0c785fd18fedb73765c0ad472717c8eea814d60d87765bbc8979
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/containers-common-1-117.el9_6.x86_64.rpm
@@ -406,7 +406,7 @@ arches:
     sourcerpm: shadow-utils-4.9-12.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/ea47724085e35131c2c8aca52dd0a74433a23c05c770b05c888c496a882bc9db-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/repodata/d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 43586
-    checksum: sha256:ea47724085e35131c2c8aca52dd0a74433a23c05c770b05c888c496a882bc9db
+    checksum: sha256:d76c8798ccdc90ff924b9ab1cb4ae74e0f6f2a5e328d1fa9a42660ce1672b4b2


### PR DESCRIPTION
## Description

Add the RHELAI RPM repo as used in the AIPCC base image [main]

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository support for Red Hat Enterprise Linux AI 3.5 on RHEL 9.
  * Enabled access to 32-bit package variants from selected repositories.

* **Updates**
  * Added `thrift` to the packages upgraded during builds.
  * Refreshed repository metadata for both ARM64 and x86_64 architectures to improve package resolution and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->